### PR TITLE
#82 - add cell failure validation message

### DIFF
--- a/cypress/integration/tests/standard/cellValidation.spec.ts
+++ b/cypress/integration/tests/standard/cellValidation.spec.ts
@@ -4,7 +4,7 @@ import { Utilities } from '../../common/utils';
 import { visit } from '../../common/visit';
 
 const utils = new Utilities(config);
-
+const INVALID_CLASS_NAME = "rg-invalid";
 context('Cell validation', () => {
 
     beforeEach(() => {
@@ -17,7 +17,7 @@ context('Cell validation', () => {
 
         utils.selectCell(config.cellWidth * 2 + utils.getCellXCenter(), config.cellHeight * 4);
         
-        utils.getCell(cellIdx, cellIdy).should('not.have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should('not.have.class', INVALID_CLASS_NAME);
     });
 
     it('should be valid email cell', () => { // ✅
@@ -25,7 +25,7 @@ context('Cell validation', () => {
         const cellIdy = 2;
         utils.selectCell(config.cellWidth * 3 + utils.getCellXCenter(), config.cellHeight * 4);
 
-        utils.getCell(cellIdx, cellIdy).should('not.have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should('not.have.class', INVALID_CLASS_NAME);
     });
 
     it('should be valid number cell', () => { // ✅
@@ -34,7 +34,7 @@ context('Cell validation', () => {
 
         utils.selectCell(config.cellWidth * 2 + utils.getCellXCenter(), config.cellHeight * 4);
         
-        utils.getCell(cellIdx, cellIdy).should('not.have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should('not.have.class', INVALID_CLASS_NAME);
     });
 
     it('should not display error when entering invalid text', () => { // ✅
@@ -50,7 +50,7 @@ context('Cell validation', () => {
         cy.focused().type("myText", { force: true });
         utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
 
-        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should('have.class', INVALID_CLASS_NAME);
         utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
     });
 
@@ -67,7 +67,7 @@ context('Cell validation', () => {
         cy.focused().type(INVALID_NUMBER, { force: true });
         utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
         
-        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should('have.class', INVALID_CLASS_NAME);
         utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.contain('ERR'));
     });
 
@@ -84,7 +84,7 @@ context('Cell validation', () => {
         cy.focused().type("abc", { force: true });
         utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
         
-        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should('have.class', INVALID_CLASS_NAME);
         utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.contain('ERR'));
     });
 
@@ -101,7 +101,7 @@ context('Cell validation', () => {
         cy.focused().type("myText", { force: true });
         utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
         
-        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should('have.class', INVALID_CLASS_NAME);
         utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.contain('ERR'));
     });
 
@@ -118,7 +118,7 @@ context('Cell validation', () => {
         cy.focused().type(INVALID_NUMBER, { force: true });
         utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
         
-        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should('have.class', INVALID_CLASS_NAME);
         utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
     });
 
@@ -135,7 +135,7 @@ context('Cell validation', () => {
         cy.focused().type("abc", { force: true });
         utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
         
-        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should('have.class', INVALID_CLASS_NAME);
         utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
     });
 
@@ -152,7 +152,7 @@ context('Cell validation', () => {
         cy.focused().type("myText", { force: true });
         utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
 
-        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should('have.class', INVALID_CLASS_NAME);
         utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
     });
 });

--- a/cypress/integration/tests/standard/cellValidation.spec.ts
+++ b/cypress/integration/tests/standard/cellValidation.spec.ts
@@ -1,0 +1,158 @@
+import { config } from '../../../../src/test/testEnvConfig';
+import { constants } from '../../common/constants';
+import { Utilities } from '../../common/utils';
+import { visit } from '../../common/visit';
+
+const utils = new Utilities(config);
+
+context('Cell validation', () => {
+
+    beforeEach(() => {
+        visit();
+    });
+
+    it('should be valid text cell', () => { // ✅
+        const cellIdx = 2;
+        const cellIdy = 2;
+
+        utils.selectCell(config.cellWidth * 2 + utils.getCellXCenter(), config.cellHeight * 4);
+        
+        utils.getCell(cellIdx, cellIdy).should('not.have.class', 'invalid');
+    });
+
+    it('should be valid email cell', () => { // ✅
+        const cellIdx = 3;
+        const cellIdy = 2;
+        utils.selectCell(config.cellWidth * 3 + utils.getCellXCenter(), config.cellHeight * 4);
+
+        utils.getCell(cellIdx, cellIdy).should('not.have.class', 'invalid');
+    });
+
+    it('should be valid number cell', () => { // ✅
+        const cellIdx = 4;
+        const cellIdy = 2;
+
+        utils.selectCell(config.cellWidth * 2 + utils.getCellXCenter(), config.cellHeight * 4);
+        
+        utils.getCell(cellIdx, cellIdy).should('not.have.class', 'invalid');
+    });
+
+    it('should not display error when entering invalid text', () => { // ✅
+        const cellIdx = 1;
+        const cellIdy = 2;
+
+        utils.selectCell(config.cellWidth * 1 + utils.getCellXCenter(), config.cellHeight * 3);
+        
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
+
+        utils.keyDown(constants.keyCodes.Delete, { force: true }, 500, true);
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+        cy.focused().type("myText", { force: true });
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+
+        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
+    });
+
+    it('should display error when entering invalid number', () => { // ✅
+        const cellIdx = 3;
+        const cellIdy = 1;
+        const INVALID_NUMBER = "1000"; // validator fails for it
+        utils.selectCell(config.cellWidth * 3 + utils.getCellXCenter(), config.cellHeight * 2);
+
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
+
+        utils.keyDown(constants.keyCodes.Delete, { force: true }, 500, true);
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+        cy.focused().type(INVALID_NUMBER, { force: true });
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+        
+        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.contain('ERR'));
+    });
+
+    it('should display error when entering invalid email', () => { // ✅
+        const cellIdx = 2;
+        const cellIdy = 1;
+
+        utils.selectCell(config.cellWidth * 2 + utils.getCellXCenter(), config.cellHeight * 2);
+        
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
+
+        utils.keyDown(constants.keyCodes.Delete, { force: true }, 500, true);
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+        cy.focused().type("abc", { force: true });
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+        
+        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.contain('ERR'));
+    });
+
+    it('should display error when entering invalid text', () => { // ✅
+        const cellIdx = 1;
+        const cellIdy = 1;
+
+        utils.selectCell(config.cellWidth * 1 + utils.getCellXCenter(), config.cellHeight * 2);
+        
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
+
+        utils.keyDown(constants.keyCodes.Delete, { force: true }, 500, true);
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+        cy.focused().type("myText", { force: true });
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+        
+        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.contain('ERR'));
+    });
+
+    it('should not display error when entering invalid number', () => { // ✅
+        const cellIdx = 3;
+        const cellIdy = 2; // this cell has validation without errorMessage
+        const INVALID_NUMBER = "1000"; // validator fails for it
+        utils.selectCell(config.cellWidth * 3 + utils.getCellXCenter(), config.cellHeight * 3);
+
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
+
+        utils.keyDown(constants.keyCodes.Delete, { force: true }, 500, true);
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+        cy.focused().type(INVALID_NUMBER, { force: true });
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+        
+        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
+    });
+
+    it('should not display error when entering invalid email', () => { // ✅
+        const cellIdx = 2;
+        const cellIdy = 2;  // this cell has validation without errorMessage
+
+        utils.selectCell(config.cellWidth * 2 + utils.getCellXCenter(), config.cellHeight * 3);
+        
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
+
+        utils.keyDown(constants.keyCodes.Delete, { force: true }, 500, true);
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+        cy.focused().type("abc", { force: true });
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+        
+        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
+    });
+
+    it('should not display error when entering invalid text', () => { // ✅
+        const cellIdx = 1;
+        const cellIdy = 2;
+
+        utils.selectCell(config.cellWidth * 1 + utils.getCellXCenter(), config.cellHeight * 3);
+        
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
+
+        utils.keyDown(constants.keyCodes.Delete, { force: true }, 500, true);
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+        cy.focused().type("myText", { force: true });
+        utils.keyDown(constants.keyCodes.Enter, { force: true }, 500, true);
+
+        utils.getCell(cellIdx, cellIdy).should('have.class', 'invalid');
+        utils.getCell(cellIdx, cellIdy).should($cell => expect($cell.eq(0)).to.not.contain('ERR'));
+    });
+});

--- a/src/lib/CellTemplates/EmailCellTemplate.tsx
+++ b/src/lib/CellTemplates/EmailCellTemplate.tsx
@@ -11,7 +11,8 @@ export interface EmailCell extends Cell {
     type: 'email',
     text: string,
     validator?: (text: string) => boolean,
-    renderer?: (text: string) => React.ReactNode
+    renderer?: (text: string) => React.ReactNode,
+    errorMessage?: string
 }
 
 export class EmailCellTemplate implements CellTemplate<EmailCell> {
@@ -39,8 +40,11 @@ export class EmailCellTemplate implements CellTemplate<EmailCell> {
     }
 
     render(cell: Compatible<EmailCell>, isInEditMode: boolean, onCellChanged: (cell: Compatible<EmailCell>, commit: boolean) => void): React.ReactNode {
-        if (!isInEditMode)
-            return cell.renderer ? cell.renderer(cell.text) : cell.text;
+        if (!isInEditMode) {
+            const isValid = cell.validator ? cell.validator(cell.text) : true;
+            const textToDisplay = !isValid && cell.errorMessage ? cell.errorMessage : cell.text;
+            return cell.renderer ? cell.renderer(textToDisplay) : textToDisplay;
+        }
 
         return <input
             ref={input => {

--- a/src/lib/CellTemplates/NumberCellTemplate.tsx
+++ b/src/lib/CellTemplates/NumberCellTemplate.tsx
@@ -64,14 +64,14 @@ export class NumberCellTemplate implements CellTemplate<NumberCell> {
     }
 
     getClassName(cell: Compatible<NumberCell>, isInEditMode: boolean): string {
-        const isValid = cell.validator ? cell.validator(cell.value) : true;
+        const isValid = cell.validator?.(cell.value) ?? true;
         const className = cell.className ? cell.className : '';
-        return `${isValid ? 'valid' : 'invalid'} ${className}`;
+        return `${!isValid ? 'rg-invalid' : ''} ${className}`;
     }
 
     render(cell: Compatible<NumberCell>, isInEditMode: boolean, onCellChanged: (cell: Compatible<NumberCell>, commit: boolean) => void): React.ReactNode {
         if (!isInEditMode) {
-            const isValid = cell.validator ? cell.validator(cell.value) : true;
+            const isValid = cell.validator?.(cell.value) ?? true;           
             const textToDisplay = !isValid && cell.errorMessage ? cell.errorMessage : cell.text;
             return textToDisplay;
         }

--- a/src/lib/CellTemplates/NumberCellTemplate.tsx
+++ b/src/lib/CellTemplates/NumberCellTemplate.tsx
@@ -10,8 +10,10 @@ export interface NumberCell extends Cell {
     type: 'number';
     value: number;
     format?: Intl.NumberFormat;
+    validator?: (value: number) => boolean,
     nanToZero?: boolean;
     hideZero?: boolean;
+    errorMessage?: string
 }
 
 export class NumberCellTemplate implements CellTemplate<NumberCell> {
@@ -62,13 +64,16 @@ export class NumberCellTemplate implements CellTemplate<NumberCell> {
     }
 
     getClassName(cell: Compatible<NumberCell>, isInEditMode: boolean): string {
-        return cell.className ? cell.className : '';
+        const isValid = cell.validator ? cell.validator(cell.value) : true;
+        const className = cell.className ? cell.className : '';
+        return `${isValid ? 'valid' : 'invalid'} ${className}`;
     }
 
     render(cell: Compatible<NumberCell>, isInEditMode: boolean, onCellChanged: (cell: Compatible<NumberCell>, commit: boolean) => void): React.ReactNode {
-
         if (!isInEditMode) {
-            return cell.text;
+            const isValid = cell.validator ? cell.validator(cell.value) : true;
+            const textToDisplay = !isValid && cell.errorMessage ? cell.errorMessage : cell.text;
+            return textToDisplay;
         }
 
         const locale = cell.format ? cell.format.resolvedOptions().locale : window.navigator.languages[0];

--- a/src/lib/CellTemplates/NumberCellTemplate.tsx
+++ b/src/lib/CellTemplates/NumberCellTemplate.tsx
@@ -65,7 +65,7 @@ export class NumberCellTemplate implements CellTemplate<NumberCell> {
 
     getClassName(cell: Compatible<NumberCell>, isInEditMode: boolean): string {
         const isValid = cell.validator?.(cell.value) ?? true;
-        const className = cell.className ? cell.className : '';
+        const className = cell.className || '';
         return `${!isValid ? 'rg-invalid' : ''} ${className}`;
     }
 

--- a/src/lib/CellTemplates/TextCellTemplate.tsx
+++ b/src/lib/CellTemplates/TextCellTemplate.tsx
@@ -12,7 +12,8 @@ export interface TextCell extends Cell {
     text: string,
     placeholder?: string;
     validator?: (text: string) => boolean,
-    renderer?: (text: string) => React.ReactNode
+    renderer?: (text: string) => React.ReactNode,
+    errorMessage?: string
 }
 
 export class TextCellTemplate implements CellTemplate<TextCell> {
@@ -49,7 +50,9 @@ export class TextCellTemplate implements CellTemplate<TextCell> {
     render(cell: Compatible<TextCell>, isInEditMode: boolean, onCellChanged: (cell: Compatible<TextCell>, commit: boolean) => void): React.ReactNode {
 
         if (!isInEditMode) {
-            const textToDisplay = cell.text === '' ? (cell.placeholder || '') : cell.text;
+            const isValid = cell.validator ? cell.validator(cell.text) : true;
+            const cellText = cell.text === '' ? (cell.placeholder || '') : cell.text;
+            const textToDisplay = !isValid && cell.errorMessage ? cell.errorMessage : cellText;
             return cell.renderer ? cell.renderer(textToDisplay) : textToDisplay;
         }
 

--- a/src/lib/CellTemplates/TextCellTemplate.tsx
+++ b/src/lib/CellTemplates/TextCellTemplate.tsx
@@ -51,7 +51,7 @@ export class TextCellTemplate implements CellTemplate<TextCell> {
 
         if (!isInEditMode) {
             const isValid = cell.validator ? cell.validator(cell.text) : true;
-            const cellText = cell.text === '' ? (cell.placeholder || '') : cell.text;
+            const cellText = cell.text || cell.placeholder || '';
             const textToDisplay = !isValid && cell.errorMessage ? cell.errorMessage : cellText;
             return cell.renderer ? cell.renderer(textToDisplay) : textToDisplay;
         }

--- a/src/test/TestGrid.tsx
+++ b/src/test/TestGrid.tsx
@@ -23,6 +23,14 @@ interface TestGridProps {
     component: React.ComponentClass<ReactGridProps>;
 }
 
+const numberValidator: NumberCell['validator'] = (number: number) => {
+    return number !== 1000;
+}
+
+const textValidator: TextCell['validator'] = (text: string) => {
+    return text !== "myText";
+}
+
 const emailValidator: TextCell['validator'] = (email) => {
     const email_regex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return email_regex.test(email.replace(/\s+/g, ''));
@@ -61,11 +69,21 @@ export const TestGrid: React.FC<TestGridProps> = (props) => {
             if (ri === 0) return { type: firstRowType, text: `${ri} - ${ci}` }
             if (ri === 2 && ci === 8) return { type: 'text', text: `non-editable`, nonEditable: true, validator: (text: string): boolean => true }
             if (ri === 3 && ci === 8) return { type: 'text', text: '', placeholder: 'placeholder', validator: (text: string): boolean => true }
+            
             const spannedCells = config.spannedCells?.filter(sC => sC.idx === ci && sC.idy === ri)[0];
             const headerCells = config.headerCells?.filter(sC => sC.idx === ci && sC.idy === ri)[0];
             if (spannedCells || headerCells) {
                 return { type: cellType, text: `${ri} - ${ci}`, colspan: spannedCells ? spannedCells.colspan : 0, rowspan: spannedCells ? spannedCells.rowspan : 0 }
             }
+
+            // spanned and header cells should "win" these conditions
+            if (ri === 1 && ci === 1) return { type: 'text', groupId: !(ri % 3) ? 'B' : undefined, text: `${ri} - ${ci}`, style, validator: textValidator, errorMessage: "ERR" };
+            if (ri === 1 && ci === 2) return { type: 'email', text: `${ri}.${ci}@bing.pl`, validator: emailValidator, errorMessage: "ERR" };
+            if (ri === 1 && ci === 3) return { type: 'number', format: myNumberFormat, validator: numberValidator, errorMessage: "ERR", value: parseFloat(`${ri}.${ci}`), nanToZero: false, hideZero: true };
+            if (ri === 2 && ci === 1) return { type: 'text', groupId: !(ri % 3) ? 'B' : undefined, text: `${ri} - ${ci}`, style, validator: textValidator };
+            if (ri === 2 && ci === 2) return { type: 'email', text: `${ri}.${ci}@bing.pl`, validator: emailValidator };
+            if (ri === 2 && ci === 3) return { type: 'number', format: myNumberFormat, validator: numberValidator, value: parseFloat(`${ri}.${ci}`), nanToZero: false, hideZero: true };
+
             const now = new Date();
             switch (ci) {
                 case 0:


### PR DESCRIPTION
We have cell validator.
When the validator fails, it adds 'invalid' calss. It means that we can control the style of the cell.

In addition, we would like to add indication in the cell value (the same as excel).
For example: #NUM!

I added tests and logic for that.
If the validator fails and there is errorMessage property, we display the errorMessage.
Otherwise, current logic exists (text/placeholder).

It should fix: #82 

Thank you very much for this amazing grid!
