### PR TITLE
retrieve border color from cell props

### DIFF
--- a/src/lib/Components/CellRenderer.tsx
+++ b/src/lib/Components/CellRenderer.tsx
@@ -68,17 +68,22 @@ export const CellRenderer: React.FC<CellRendererProps> = ({
 
     const storePropertyAndDefaultValue = storeBorderAndCell(borders, cell);
     const bordersWidth = getBorderProperties(storePropertyAndDefaultValue('width', '1px')),
-        bordersStyle = getBorderProperties(storePropertyAndDefaultValue('style', 'solid'));
+        bordersStyle = getBorderProperties(storePropertyAndDefaultValue('style', 'solid')),
+        bordersColor = getBorderProperties(storePropertyAndDefaultValue('color', 'e8e8e8'));
 
     const bordersProps = {
         borderLeftWidth: bordersWidth.left,
         borderLeftStyle: bordersStyle.left,
+        borderLeftColor: bordersColor.left,
         borderRightWidth: bordersWidth.right,
         borderRightStyle: bordersStyle.right,
+        borderRightColor: bordersColor.right,
         borderTopWidth: bordersWidth.top,
         borderTopStyle: bordersStyle.top,
+        borderTopColor: bordersColor.top,
         borderBottomWidth: bordersWidth.bottom,
         borderBottomStyle: bordersStyle.bottom,
+        borderBottomColor: bordersColor.bottom
     };
 
     const isMobile = isMobileDevice();


### PR DESCRIPTION
This PR fixes #122 and #137 by retrieving and setting border color properties in cell renderer. 