### PR TITLE
Fix/i18n first input char

### DIFF
--- a/src/lib/CellTemplates/ChevronCellTemplate.tsx
+++ b/src/lib/CellTemplates/ChevronCellTemplate.tsx
@@ -5,7 +5,7 @@ import { getCellProperty } from '../Functions/getCellProperty';
 import { keyCodes } from '../Functions/keyCodes';
 import { Cell, CellStyle, CellTemplate, Compatible, Id, Uncertain, UncertainCompatible } from '../Model/PublicModel';
 import { isNavigationKey, isAlphaNumericKey } from './keyCodeCheckings';
-import { getCharFromKeyCode } from './getCharFromKeyCode';
+import { getCharFromKey, getCharFromKeyCode } from './getCharFromKeyCode';
 
 export interface ChevronCell extends Cell {
     type: 'chevron';
@@ -47,14 +47,16 @@ export class ChevronCellTemplate implements CellTemplate<ChevronCell> {
         return this.getCompatibleCell({ ...cell, isExpanded: cellToMerge.isExpanded, text: cellToMerge.text })
     }
 
-    handleKeyDown(cell: Compatible<ChevronCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean): { cell: Compatible<ChevronCell>, enableEditMode: boolean } {
+    handleKeyDown(cell: Compatible<ChevronCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<ChevronCell>, enableEditMode: boolean } {
         let enableEditMode = keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER;
         const cellCopy = { ...cell };
-        const char = getCharFromKeyCode(keyCode, shift);
+
+        const char = getCharFromKey(key, shift);
+
         if (keyCode === keyCodes.SPACE && cellCopy.isExpanded !== undefined && !shift) {
             cellCopy.isExpanded = !cellCopy.isExpanded;
         } else if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE)) {
-            cellCopy.text = !shift ? char.toLowerCase() : char;
+            cellCopy.text = char;
             enableEditMode = true;
         }
         return { cell: cellCopy, enableEditMode };

--- a/src/lib/CellTemplates/DropdownCellTemplate.tsx
+++ b/src/lib/CellTemplates/DropdownCellTemplate.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'
 import { getCellProperty } from '../Functions/getCellProperty';
-import { getCharFromKeyCode } from './getCharFromKeyCode';
+import { getCharFromKey, getCharFromKeyCode } from './getCharFromKeyCode';
 import { isAlphaNumericKey } from './keyCodeCheckings';
 import { Cell, CellTemplate, Compatible, Uncertain, UncertainCompatible } from '../Model/PublicModel';
 import { keyCodes } from '../Functions/keyCodes';
@@ -73,15 +73,15 @@ export class DropdownCellTemplate implements CellTemplate<DropdownCell> {
         return `${cell.className ? cell.className : ''}${isOpen}`;
     }
 
-    handleKeyDown(cell: Compatible<DropdownCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean): { cell: Compatible<DropdownCell>, enableEditMode: boolean } {
+    handleKeyDown(cell: Compatible<DropdownCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<DropdownCell>, enableEditMode: boolean } {
         if ((keyCode === keyCodes.SPACE || keyCode === keyCodes.ENTER) && !shift) {
             return { cell: this.getCompatibleCell({ ...cell, isOpen: !cell.isOpen }), enableEditMode: false };
         }
 
-        const char = getCharFromKeyCode(keyCode, shift);
+        const char = getCharFromKey(key, shift);
 
         if (!ctrl && !alt && isAlphaNumericKey(keyCode))
-            return { cell: this.getCompatibleCell({ ...cell, inputValue: shift ? char : char.toLowerCase(), isOpen: !cell.isOpen }), enableEditMode: false }
+            return { cell: this.getCompatibleCell({ ...cell, inputValue: char, isOpen: !cell.isOpen }), enableEditMode: false }
 
         return { cell, enableEditMode: false };
     }

--- a/src/lib/CellTemplates/EmailCellTemplate.tsx
+++ b/src/lib/CellTemplates/EmailCellTemplate.tsx
@@ -5,7 +5,7 @@ import { isAlphaNumericKey, isNavigationKey } from './keyCodeCheckings';
 import { getCellProperty } from '../Functions/getCellProperty';
 import { keyCodes } from '../Functions/keyCodes';
 import { Cell, CellTemplate, Compatible, Uncertain, UncertainCompatible } from '../Model/PublicModel';
-import { getCharFromKeyCode } from './getCharFromKeyCode';
+import { getCharFromKey, getCharFromKeyCode } from './getCharFromKeyCode';
 
 export interface EmailCell extends Cell {
     type: 'email',
@@ -24,10 +24,11 @@ export class EmailCellTemplate implements CellTemplate<EmailCell> {
         return { ...uncertainCell, text, value };
     }
 
-    handleKeyDown(cell: Compatible<EmailCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean): { cell: Compatible<EmailCell>, enableEditMode: boolean } {
-        const char = getCharFromKeyCode(keyCode, shift);
+    handleKeyDown(cell: Compatible<EmailCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<EmailCell>, enableEditMode: boolean } {
+        const char = getCharFromKey(key, shift);
+
         if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE))
-            return { cell: { ...cell, text: !shift ? char.toLowerCase() : char }, enableEditMode: true }
+            return { cell: { ...cell, text: char }, enableEditMode: true }
         return { cell, enableEditMode: keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER }
     }
 

--- a/src/lib/CellTemplates/TextCellTemplate.tsx
+++ b/src/lib/CellTemplates/TextCellTemplate.tsx
@@ -5,7 +5,7 @@ import { isAlphaNumericKey, isNavigationKey } from './keyCodeCheckings'
 import { getCellProperty } from '../Functions/getCellProperty';
 import { keyCodes } from '../Functions/keyCodes';
 import { Cell, CellTemplate, Compatible, Uncertain, UncertainCompatible } from '../Model/PublicModel';
-import { getCharFromKeyCode } from './getCharFromKeyCode';
+import { getCharFromKey, getCharFromKeyCode } from './getCharFromKeyCode';
 
 export interface TextCell extends Cell {
     type: 'text',
@@ -36,12 +36,10 @@ export class TextCellTemplate implements CellTemplate<TextCell> {
     }
 
     handleKeyDown(cell: Compatible<TextCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<TextCell>, enableEditMode: boolean } {
-        // const char = getCharFromKeyCode(keyCode, shift);
-        const activeLanguage = navigator.language || 'en-US';
-        const char = key.toLocaleLowerCase(activeLanguage);
+        const char = getCharFromKey(key, shift);
 
         if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE))
-            return { cell: this.getCompatibleCell({ ...cell, text: shift ? char : char.toLowerCase() }), enableEditMode: true }
+            return { cell: this.getCompatibleCell({ ...cell, text: char }), enableEditMode: true }
         return { cell, enableEditMode: keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER }
     }
 

--- a/src/lib/CellTemplates/TextCellTemplate.tsx
+++ b/src/lib/CellTemplates/TextCellTemplate.tsx
@@ -35,8 +35,11 @@ export class TextCellTemplate implements CellTemplate<TextCell> {
         return this.getCompatibleCell({ ...cell, text: cellToMerge.text, placeholder: cellToMerge.placeholder })
     }
 
-    handleKeyDown(cell: Compatible<TextCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean): { cell: Compatible<TextCell>, enableEditMode: boolean } {
-        const char = getCharFromKeyCode(keyCode, shift);
+    handleKeyDown(cell: Compatible<TextCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<TextCell>, enableEditMode: boolean } {
+        // const char = getCharFromKeyCode(keyCode, shift);
+        const activeLanguage = navigator.language || 'en-US';
+        const char = key.toLocaleLowerCase(activeLanguage);
+
         if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE))
             return { cell: this.getCompatibleCell({ ...cell, text: shift ? char : char.toLowerCase() }), enableEditMode: true }
         return { cell, enableEditMode: keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER }

--- a/src/lib/CellTemplates/getCharFromKeyCode.ts
+++ b/src/lib/CellTemplates/getCharFromKeyCode.ts
@@ -207,3 +207,9 @@ characterMap[222] = "'";
 export const getCharFromKeyCode = (keyCode: number, isShiftKey = false): string => {
     return isShiftKey ? characterMapShift[keyCode] : characterMap[keyCode];
 }
+
+export const getCharFromKey = (key: string, isShiftKey = false): string => {
+    const activeLanguage = navigator.language || 'en-US';
+
+    return !isShiftKey ? key.toLocaleLowerCase(activeLanguage) : key.toLocaleUpperCase(activeLanguage);
+}

--- a/src/lib/Functions/handleKeyDownOnCellTemplate.ts
+++ b/src/lib/Functions/handleKeyDownOnCellTemplate.ts
@@ -11,7 +11,7 @@ export function handleKeyDownOnCellTemplate(state: State, event: KeyboardEvent):
     }
     const { cell, cellTemplate } = getCompatibleCellAndTemplate(state, location);
     if (cellTemplate.handleKeyDown && !state.currentlyEditedCell) { // TODO need add !(event.shiftKey && event.keyCode === keyCodes.SPACE) to working keycodes (shift + space) in a lower condition
-        const { cell: newCell, enableEditMode } = cellTemplate.handleKeyDown(cell, event.keyCode, isSelectionKey(event), event.shiftKey, event.altKey);
+        const { cell: newCell, enableEditMode } = cellTemplate.handleKeyDown(cell, event.keyCode, isSelectionKey(event), event.shiftKey, event.altKey, event.key);
         if (JSON.stringify(newCell) !== JSON.stringify(cell) || enableEditMode) {
             if (enableEditMode && !cell.nonEditable) {
                 return { ...state, currentlyEditedCell: newCell }

--- a/src/lib/Model/PublicModel.ts
+++ b/src/lib/Model/PublicModel.ts
@@ -331,6 +331,7 @@ export interface CellTemplate<TCell extends Cell = Cell> {
      * @param {boolean} ctrl Is `ctrl` pressed when event is called ()
      * @param {boolean} shift Is `shift` pressed when event is called
      * @param {boolean} alt Is `alt` pressed when event is called
+     * @param {string} key Represents the value of the key pressed by the user
      * @returns {{ cell: Compatible<TCell>; enableEditMode: boolean }} Cell data and edit mode either affected by the event or not
     */
     handleKeyDown?(
@@ -338,7 +339,8 @@ export interface CellTemplate<TCell extends Cell = Cell> {
         keyCode: number,
         ctrl: boolean,
         shift: boolean,
-        alt: boolean
+        alt: boolean,
+        key?: string
     ): { cell: Compatible<TCell>; enableEditMode: boolean };
 
     /**

--- a/src/lib/Model/PublicModel.ts
+++ b/src/lib/Model/PublicModel.ts
@@ -331,7 +331,7 @@ export interface CellTemplate<TCell extends Cell = Cell> {
      * @param {boolean} ctrl Is `ctrl` pressed when event is called ()
      * @param {boolean} shift Is `shift` pressed when event is called
      * @param {boolean} alt Is `alt` pressed when event is called
-     * @param {string} key Represents the value of the key pressed by the user
+     * @param {string} [key] Represents the value of the key pressed by the user. Optional for backwards compatibility.
      * @returns {{ cell: Compatible<TCell>; enableEditMode: boolean }} Cell data and edit mode either affected by the event or not
     */
     handleKeyDown?(

--- a/src/test/flagCell/FlagCellTemplate.tsx
+++ b/src/test/flagCell/FlagCellTemplate.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {
     CellTemplate, Cell, Compatible, Uncertain, UncertainCompatible, isNavigationKey, getCellProperty,
-    isAlphaNumericKey, keyCodes
+    isAlphaNumericKey, keyCodes, getCharFromKey
 } from '../../reactgrid';
 import './flag-cell-style.scss';
 
@@ -19,9 +19,11 @@ export class FlagCellTemplate implements CellTemplate<FlagCell> {
         return { ...uncertainCell, text, value };
     }
 
-    handleKeyDown(cell: Compatible<FlagCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean): { cell: Compatible<FlagCell>, enableEditMode: boolean } {
+    handleKeyDown(cell: Compatible<FlagCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<FlagCell>, enableEditMode: boolean } {
+        const char = getCharFromKey(key, shift);
+
         if (!ctrl && !alt && isAlphaNumericKey(keyCode))
-            return { cell, enableEditMode: true }
+            return { cell: { ...cell, text: char }, enableEditMode: true }
         return { cell, enableEditMode: keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER }
     }
 


### PR DESCRIPTION
This pull request fixes a bug (#118) in which first alphanumeric key pressed (on a focused cell, that *isn't* in edit mode), always produced it's english keyboard layout's equivalent. To address that I added a `key` property to cell's key down handler inside PublicModel, created function that retrieves proper character and updated cell templates to use it.