### PR TITLE
Catch all printable characters on first input outside edit mode

### DIFF
--- a/src/lib/CellTemplates/ChevronCellTemplate.tsx
+++ b/src/lib/CellTemplates/ChevronCellTemplate.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { getCellProperty } from '../Functions/getCellProperty';
 import { keyCodes } from '../Functions/keyCodes';
 import { Cell, CellStyle, CellTemplate, Compatible, Id, Uncertain, UncertainCompatible } from '../Model/PublicModel';
-import { isNavigationKey, isAlphaNumericKey } from './keyCodeCheckings';
+import { isNavigationKey, isAlphaNumericKey, isCharAlphaNumeric, isKeyPrintable } from './keyCodeCheckings';
 import { getCharFromKey, getCharFromKeyCode } from './getCharFromKeyCode';
 
 export interface ChevronCell extends Cell {
@@ -51,11 +51,11 @@ export class ChevronCellTemplate implements CellTemplate<ChevronCell> {
         let enableEditMode = keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER;
         const cellCopy = { ...cell };
 
-        const char = getCharFromKey(key, shift);
+        const char = getCharFromKey(key);
 
         if (keyCode === keyCodes.SPACE && cellCopy.isExpanded !== undefined && !shift) {
             cellCopy.isExpanded = !cellCopy.isExpanded;
-        } else if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE)) {
+        } else if (isCharAlphaNumeric(char) && !(shift && keyCode === keyCodes.SPACE)) {
             cellCopy.text = char;
             enableEditMode = true;
         }

--- a/src/lib/CellTemplates/ChevronCellTemplate.tsx
+++ b/src/lib/CellTemplates/ChevronCellTemplate.tsx
@@ -55,7 +55,7 @@ export class ChevronCellTemplate implements CellTemplate<ChevronCell> {
 
         if (keyCode === keyCodes.SPACE && cellCopy.isExpanded !== undefined && !shift) {
             cellCopy.isExpanded = !cellCopy.isExpanded;
-        } else if (isCharAlphaNumeric(char) && !(shift && keyCode === keyCodes.SPACE)) {
+        } else if (!ctrl && isKeyPrintable(key) && !(shift && keyCode === keyCodes.SPACE)) {
             cellCopy.text = char;
             enableEditMode = true;
         }

--- a/src/lib/CellTemplates/DateCellTemplate.tsx
+++ b/src/lib/CellTemplates/DateCellTemplate.tsx
@@ -4,8 +4,9 @@ import * as React from 'react';
 import { getCellProperty } from '../Functions/getCellProperty';
 import { Cell, CellTemplate, Compatible, Uncertain, UncertainCompatible } from '../Model/PublicModel';
 import { keyCodes } from '../Functions/keyCodes';
-import { inNumericKey, isNavigationKey, isAlphaNumericKey } from './keyCodeCheckings';
+import { inNumericKey, isNavigationKey, isAlphaNumericKey, isCharAlphaNumeric } from './keyCodeCheckings';
 import { getTimestamp, getFormattedTimeUnit } from './timeUtils';
+import { getCharFromKey } from './getCharFromKeyCode';
 
 export interface DateCell extends Cell {
     type: 'date';
@@ -24,8 +25,8 @@ export class DateCellTemplate implements CellTemplate<DateCell> {
         return { ...uncertainCell, date, value, text }
     }
 
-    handleKeyDown(cell: Compatible<DateCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean): { cell: Compatible<DateCell>, enableEditMode: boolean } {
-        if (!ctrl && !alt && !shift && isAlphaNumericKey(keyCode))
+    handleKeyDown(cell: Compatible<DateCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<DateCell>, enableEditMode: boolean } {
+        if (isCharAlphaNumeric(getCharFromKey(key)))
             return { cell: this.getCompatibleCell({ ...cell }), enableEditMode: true }
         return { cell, enableEditMode: keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER }
     }

--- a/src/lib/CellTemplates/DateCellTemplate.tsx
+++ b/src/lib/CellTemplates/DateCellTemplate.tsx
@@ -26,7 +26,7 @@ export class DateCellTemplate implements CellTemplate<DateCell> {
     }
 
     handleKeyDown(cell: Compatible<DateCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<DateCell>, enableEditMode: boolean } {
-        if (isCharAlphaNumeric(getCharFromKey(key)))
+        if (!ctrl && isCharAlphaNumeric(getCharFromKey(key)))
             return { cell: this.getCompatibleCell({ ...cell }), enableEditMode: true }
         return { cell, enableEditMode: keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER }
     }

--- a/src/lib/CellTemplates/DropdownCellTemplate.tsx
+++ b/src/lib/CellTemplates/DropdownCellTemplate.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'
 import { getCellProperty } from '../Functions/getCellProperty';
 import { getCharFromKey, getCharFromKeyCode } from './getCharFromKeyCode';
-import { isAlphaNumericKey } from './keyCodeCheckings';
+import { isAlphaNumericKey, isKeyPrintable } from './keyCodeCheckings';
 import { Cell, CellTemplate, Compatible, Uncertain, UncertainCompatible } from '../Model/PublicModel';
 import { keyCodes } from '../Functions/keyCodes';
 
@@ -80,7 +80,7 @@ export class DropdownCellTemplate implements CellTemplate<DropdownCell> {
 
         const char = getCharFromKey(key);
 
-        if (!ctrl && !alt && isAlphaNumericKey(keyCode))
+        if (!ctrl && isKeyPrintable(key) && !(shift && keyCode === keyCodes.SPACE))
             return { cell: this.getCompatibleCell({ ...cell, inputValue: char, isOpen: !cell.isOpen }), enableEditMode: false }
 
         return { cell, enableEditMode: false };

--- a/src/lib/CellTemplates/DropdownCellTemplate.tsx
+++ b/src/lib/CellTemplates/DropdownCellTemplate.tsx
@@ -78,7 +78,7 @@ export class DropdownCellTemplate implements CellTemplate<DropdownCell> {
             return { cell: this.getCompatibleCell({ ...cell, isOpen: !cell.isOpen }), enableEditMode: false };
         }
 
-        const char = getCharFromKey(key, shift);
+        const char = getCharFromKey(key);
 
         if (!ctrl && !alt && isAlphaNumericKey(keyCode))
             return { cell: this.getCompatibleCell({ ...cell, inputValue: char, isOpen: !cell.isOpen }), enableEditMode: false }

--- a/src/lib/CellTemplates/EmailCellTemplate.tsx
+++ b/src/lib/CellTemplates/EmailCellTemplate.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'
-import { isAlphaNumericKey, isNavigationKey } from './keyCodeCheckings';
+import { isAlphaNumericKey, isKeyPrintable, isNavigationKey } from './keyCodeCheckings';
 import { getCellProperty } from '../Functions/getCellProperty';
 import { keyCodes } from '../Functions/keyCodes';
 import { Cell, CellTemplate, Compatible, Uncertain, UncertainCompatible } from '../Model/PublicModel';
@@ -27,7 +27,7 @@ export class EmailCellTemplate implements CellTemplate<EmailCell> {
     handleKeyDown(cell: Compatible<EmailCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<EmailCell>, enableEditMode: boolean } {
         const char = getCharFromKey(key);
 
-        if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE))
+        if (!ctrl && isKeyPrintable(key) && !(shift && keyCode === keyCodes.SPACE))
             return { cell: { ...cell, text: char }, enableEditMode: true }
         return { cell, enableEditMode: keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER }
     }

--- a/src/lib/CellTemplates/EmailCellTemplate.tsx
+++ b/src/lib/CellTemplates/EmailCellTemplate.tsx
@@ -25,7 +25,7 @@ export class EmailCellTemplate implements CellTemplate<EmailCell> {
     }
 
     handleKeyDown(cell: Compatible<EmailCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<EmailCell>, enableEditMode: boolean } {
-        const char = getCharFromKey(key, shift);
+        const char = getCharFromKey(key);
 
         if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE))
             return { cell: { ...cell, text: char }, enableEditMode: true }

--- a/src/lib/CellTemplates/NumberCellTemplate.tsx
+++ b/src/lib/CellTemplates/NumberCellTemplate.tsx
@@ -35,7 +35,7 @@ export class NumberCellTemplate implements CellTemplate<NumberCell> {
 
     handleKeyDown(cell: Compatible<NumberCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<NumberCell>; enableEditMode: boolean } {
         if (isNumpadNumericKey(keyCode)) keyCode -= 48;
-        const char = getCharFromKey(key, shift);
+        const char = getCharFromKey(key);
         if (isCharAllowedOnNumberInput(char)) {
             const value = Number(char);
 

--- a/src/lib/CellTemplates/NumberCellTemplate.tsx
+++ b/src/lib/CellTemplates/NumberCellTemplate.tsx
@@ -4,7 +4,8 @@ import * as React from 'react';
 import { getCellProperty } from '../Functions/getCellProperty';
 import { keyCodes } from '../Functions/keyCodes';
 import { Cell, CellTemplate, Compatible, Uncertain, UncertainCompatible } from '../Model/PublicModel';
-import { inNumericKey, isNavigationKey, isNumpadNumericKey, isAllowedOnNumberTypingKey } from './keyCodeCheckings';
+import { inNumericKey, isNavigationKey, isNumpadNumericKey, isAllowedOnNumberTypingKey, isCharAllowedOnNumberInput } from './keyCodeCheckings';
+import { getCharFromKey } from './getCharFromKeyCode';
 
 export interface NumberCell extends Cell {
     type: 'number';
@@ -32,12 +33,15 @@ export class NumberCellTemplate implements CellTemplate<NumberCell> {
         return { ...uncertainCell, value: displayValue, text }
     }
 
-    handleKeyDown(cell: Compatible<NumberCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean): { cell: Compatible<NumberCell>; enableEditMode: boolean } {
+    handleKeyDown(cell: Compatible<NumberCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<NumberCell>; enableEditMode: boolean } {
         if (isNumpadNumericKey(keyCode)) keyCode -= 48;
-        const char = String.fromCharCode(keyCode);
-        if (!ctrl && !alt && !shift && (inNumericKey(keyCode) || isAllowedOnNumberTypingKey(keyCode))) {
+        const char = getCharFromKey(key, shift);
+        if (isCharAllowedOnNumberInput(char)) {
             const value = Number(char);
-            if (Number.isNaN(value) && isAllowedOnNumberTypingKey(keyCode))
+
+            console.log(value, Number.isNaN(value), isCharAllowedOnNumberInput(char))
+
+            if (Number.isNaN(value) && isCharAllowedOnNumberInput(char))
                 return { cell: { ...this.getCompatibleCell({ ...cell, value }), text: char }, enableEditMode: true }
             return { cell: this.getCompatibleCell({ ...cell, value }), enableEditMode: true }
         }
@@ -93,7 +97,7 @@ export class NumberCellTemplate implements CellTemplate<NumberCell> {
             onBlur={e => { onCellChanged(this.getCompatibleCell({ ...cell, value: parseFloat(e.currentTarget.value.replace(/,/g, '.')) }), !this.wasEscKeyPressed); this.wasEscKeyPressed = false; }}
             onKeyDown={e => {
                 if (inNumericKey(e.keyCode) || isNavigationKey(e.keyCode) || isAllowedOnNumberTypingKey(e.keyCode)) e.stopPropagation();
-                if ((!inNumericKey(e.keyCode) && !isNavigationKey(e.keyCode) && !isAllowedOnNumberTypingKey(e.keyCode)) || e.shiftKey) e.preventDefault();
+                if (!inNumericKey(e.keyCode) && !isNavigationKey(e.keyCode) && !isCharAllowedOnNumberInput(getCharFromKey(e.key))) e.preventDefault();
                 if (e.keyCode === keyCodes.ESCAPE) this.wasEscKeyPressed = true;
             }}
             onCopy={e => e.stopPropagation()}

--- a/src/lib/CellTemplates/NumberCellTemplate.tsx
+++ b/src/lib/CellTemplates/NumberCellTemplate.tsx
@@ -36,10 +36,8 @@ export class NumberCellTemplate implements CellTemplate<NumberCell> {
     handleKeyDown(cell: Compatible<NumberCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<NumberCell>; enableEditMode: boolean } {
         if (isNumpadNumericKey(keyCode)) keyCode -= 48;
         const char = getCharFromKey(key);
-        if (isCharAllowedOnNumberInput(char)) {
+        if (!ctrl && isCharAllowedOnNumberInput(char)) {
             const value = Number(char);
-
-            console.log(value, Number.isNaN(value), isCharAllowedOnNumberInput(char))
 
             if (Number.isNaN(value) && isCharAllowedOnNumberInput(char))
                 return { cell: { ...this.getCompatibleCell({ ...cell, value }), text: char }, enableEditMode: true }

--- a/src/lib/CellTemplates/TextCellTemplate.tsx
+++ b/src/lib/CellTemplates/TextCellTemplate.tsx
@@ -36,7 +36,7 @@ export class TextCellTemplate implements CellTemplate<TextCell> {
     }
 
     handleKeyDown(cell: Compatible<TextCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<TextCell>, enableEditMode: boolean } {
-        const char = getCharFromKey(key, shift);
+        const char = getCharFromKey(key);
 
         if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE))
             return { cell: this.getCompatibleCell({ ...cell, text: char }), enableEditMode: true }

--- a/src/lib/CellTemplates/TextCellTemplate.tsx
+++ b/src/lib/CellTemplates/TextCellTemplate.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'
-import { isAlphaNumericKey, isNavigationKey } from './keyCodeCheckings'
+import { isAlphaNumericKey, isKeyPrintable, isNavigationKey } from './keyCodeCheckings'
 import { getCellProperty } from '../Functions/getCellProperty';
 import { keyCodes } from '../Functions/keyCodes';
 import { Cell, CellTemplate, Compatible, Uncertain, UncertainCompatible } from '../Model/PublicModel';
@@ -38,7 +38,7 @@ export class TextCellTemplate implements CellTemplate<TextCell> {
     handleKeyDown(cell: Compatible<TextCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<TextCell>, enableEditMode: boolean } {
         const char = getCharFromKey(key);
 
-        if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE))
+        if (!ctrl && isKeyPrintable(key) && !(shift && keyCode === keyCodes.SPACE))
             return { cell: this.getCompatibleCell({ ...cell, text: char }), enableEditMode: true }
         return { cell, enableEditMode: keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER }
     }

--- a/src/lib/CellTemplates/TimeCellTemplate.tsx
+++ b/src/lib/CellTemplates/TimeCellTemplate.tsx
@@ -4,8 +4,9 @@ import * as React from 'react';
 import { getCellProperty } from '../Functions/getCellProperty';
 import { keyCodes } from '../Functions/keyCodes';
 import { Cell, CellTemplate, Compatible, Uncertain, UncertainCompatible } from '../Model/PublicModel';
-import { inNumericKey, isNavigationKey, isAlphaNumericKey } from './keyCodeCheckings'
+import { inNumericKey, isNavigationKey, isAlphaNumericKey, isCharAllowedOnNumberInput } from './keyCodeCheckings'
 import { getTimestamp, getFormattedTimeUnit, getDefaultDate } from './timeUtils';
+import { getCharFromKey } from './getCharFromKeyCode';
 
 export interface TimeCell extends Cell {
     type: 'time';
@@ -27,8 +28,8 @@ export class TimeCellTemplate implements CellTemplate<TimeCell> {
         return { ...uncertainCell, time, value, text }
     }
 
-    handleKeyDown(cell: Compatible<TimeCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean): { cell: Compatible<TimeCell>, enableEditMode: boolean } {
-        if (!ctrl && !alt && !shift && isAlphaNumericKey(keyCode))
+    handleKeyDown(cell: Compatible<TimeCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<TimeCell>, enableEditMode: boolean } {
+        if (!ctrl && isCharAllowedOnNumberInput(getCharFromKey(key)))
             return { cell: this.getCompatibleCell({ ...cell }), enableEditMode: true }
         return { cell, enableEditMode: keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER }
     }

--- a/src/lib/CellTemplates/getCharFromKeyCode.ts
+++ b/src/lib/CellTemplates/getCharFromKeyCode.ts
@@ -1,3 +1,5 @@
+import { isKeyPrintable } from "./keyCodeCheckings";
+
 const characterMapShift: string[] = [];
 characterMapShift[8] = "";
 characterMapShift[9] = "";
@@ -209,7 +211,5 @@ export const getCharFromKeyCode = (keyCode: number, isShiftKey = false): string 
 }
 
 export const getCharFromKey = (key: string, isShiftKey = false): string => {
-    const activeLanguage = navigator.language || 'en-US';
-
-    return !isShiftKey ? key.toLocaleLowerCase(activeLanguage) : key.toLocaleUpperCase(activeLanguage);
+    return isKeyPrintable(key) ? key : "";
 }

--- a/src/lib/CellTemplates/keyCodeCheckings.ts
+++ b/src/lib/CellTemplates/keyCodeCheckings.ts
@@ -48,6 +48,8 @@ export const isAllowedOnNumberTypingKey = (keyCode: number): boolean =>
     (keyCode >= keyCodes.COMMA && keyCode <= keyCodes.PERIOD)
     || keyCode === keyCodes.DECIMAL || keyCode === keyCodes.SUBTRACT || keyCode === keyCodes.FIREFOX_DASH;
 
+export const isCharAllowedOnNumberInput = (char: string): boolean => char.match(/[\d.,+-]/) !== null;
+
 /**
  * Checks that the pressed key's `keyCode` is one of navigation keys 
  * 

--- a/src/lib/CellTemplates/keyCodeCheckings.ts
+++ b/src/lib/CellTemplates/keyCodeCheckings.ts
@@ -16,6 +16,14 @@ export const isAlphaNumericKey = (keyCode: number): boolean =>
     keyCode === keyCodes.SPACE;
 
 /**
+ * Similar to {@link isAlphaNumericKey} - checks that the provided `char` is one of alphanumeric characters
+ * 
+ * @param {string} char character produced by `KeyboardEvent.key` field
+ * @returns {boolean} Returns `true` if `char` is one of alphanumeric characters
+ */
+export const isCharAlphaNumeric = (char: string): boolean => char.match(/[a-zA-Z0-9]/) !== null;
+
+/**
  * Checks that the pressed key's `keyCode` is one of numeric keys
  * 
  * @param {number} keyCode `keyCode` field from `KeyboardEvent` interface 
@@ -48,6 +56,12 @@ export const isAllowedOnNumberTypingKey = (keyCode: number): boolean =>
     (keyCode >= keyCodes.COMMA && keyCode <= keyCodes.PERIOD)
     || keyCode === keyCodes.DECIMAL || keyCode === keyCodes.SUBTRACT || keyCode === keyCodes.FIREFOX_DASH;
 
+/**
+ * Similar to {@link isAllowedOnNumberTypingKey} - checks that the provided `char` is allowed while typing numeric value e.g. `-3.14`
+ * 
+ * @param {string} char character produced by `KeyboardEvent.key` field
+ * @returns {boolean} Returns `true` if `char` is one of allowed while typing numeric value
+ */
 export const isCharAllowedOnNumberInput = (char: string): boolean => char.match(/[\d.,+-]/) !== null;
 
 /**

--- a/src/lib/CellTemplates/keyCodeCheckings.ts
+++ b/src/lib/CellTemplates/keyCodeCheckings.ts
@@ -23,6 +23,11 @@ export const isAlphaNumericKey = (keyCode: number): boolean =>
  */
 export const isCharAlphaNumeric = (char: string): boolean => char.match(/^[a-zA-Z0-9]$/) !== null;
 
+/**
+ * Helper function to check that the provided `key` produces printable character
+ * @param key field from `KeyboardEvent` interface
+ * @returns Returns `true` if `key` is one of printable characters
+ */
 export const isKeyPrintable = (key: string): boolean => key.length === 1;
 
 /**

--- a/src/lib/CellTemplates/keyCodeCheckings.ts
+++ b/src/lib/CellTemplates/keyCodeCheckings.ts
@@ -21,7 +21,9 @@ export const isAlphaNumericKey = (keyCode: number): boolean =>
  * @param {string} char character produced by `KeyboardEvent.key` field
  * @returns {boolean} Returns `true` if `char` is one of alphanumeric characters
  */
-export const isCharAlphaNumeric = (char: string): boolean => char.match(/[a-zA-Z0-9]/) !== null;
+export const isCharAlphaNumeric = (char: string): boolean => char.match(/^[a-zA-Z0-9]$/) !== null;
+
+export const isKeyPrintable = (key: string): boolean => key.length === 1;
 
 /**
  * Checks that the pressed key's `keyCode` is one of numeric keys

--- a/src/test/flagCell/FlagCellTemplate.tsx
+++ b/src/test/flagCell/FlagCellTemplate.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {
     CellTemplate, Cell, Compatible, Uncertain, UncertainCompatible, isNavigationKey, getCellProperty,
-    isAlphaNumericKey, keyCodes, getCharFromKey
+    isAlphaNumericKey, keyCodes, getCharFromKey, isKeyPrintable
 } from '../../reactgrid';
 import './flag-cell-style.scss';
 
@@ -22,7 +22,7 @@ export class FlagCellTemplate implements CellTemplate<FlagCell> {
     handleKeyDown(cell: Compatible<FlagCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<FlagCell>, enableEditMode: boolean } {
         const char = getCharFromKey(key);
 
-        if (!ctrl && !alt && isAlphaNumericKey(keyCode))
+        if (!ctrl && isKeyPrintable(key) && !(shift && keyCode === keyCodes.SPACE))
             return { cell: { ...cell, text: char }, enableEditMode: true }
         return { cell, enableEditMode: keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER }
     }

--- a/src/test/flagCell/FlagCellTemplate.tsx
+++ b/src/test/flagCell/FlagCellTemplate.tsx
@@ -20,7 +20,7 @@ export class FlagCellTemplate implements CellTemplate<FlagCell> {
     }
 
     handleKeyDown(cell: Compatible<FlagCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<FlagCell>, enableEditMode: boolean } {
-        const char = getCharFromKey(key, shift);
+        const char = getCharFromKey(key);
 
         if (!ctrl && !alt && isAlphaNumericKey(keyCode))
             return { cell: { ...cell, text: char }, enableEditMode: true }


### PR DESCRIPTION
This PR aims to fix an issue where foreign languages characters weren't caught on first keyboard input outside edit mode.