### PR TITLE
Restore mistakenly deleted moveRightOnEnter prop

### DIFF
--- a/src/lib/Model/PublicModel.ts
+++ b/src/lib/Model/PublicModel.ts
@@ -66,15 +66,19 @@ export interface ReactGridProps {
      * Horizontal breakpoint in percents (%) of ReactGrid scrollable parent element width. 
      * Disables sticky when the sum of the sizes of sticky panes overflows
      * given breakpoint value (by default `50`).
-    */
+     */
     readonly horizontalStickyBreakpoint?: number;
     /** 
      * Vertical breakpoint in percents (%) of ReactGrid scrollable parent element height. 
      * Disables sticky when the sum of the sizes of sticky panes overflows
      * given breakpoint value (by default `50`).
-    */
+     */
     readonly verticalStickyBreakpoint?: number;
 
+    /**
+     * When pressing `Enter` key, move focus to the next column (by default `false`)
+     */
+    readonly moveRightOnEnter?: boolean;
 
     /** 
      * Called when cell was changed (e.g. property `value`)


### PR DESCRIPTION
While merging #140 with develop I mistakenly removed `moveRightOnEnter` property from `PublicModel`.