### PR TITLE
Revert prop that disables CellEditor fixed position

### DIFF
--- a/src/lib/Components/CellEditor.tsx
+++ b/src/lib/Components/CellEditor.tsx
@@ -51,7 +51,7 @@ export const CellEditorRenderer: React.FC = () => {
             left: position.left && position.left - 1,
             height: location.row.height + 1,
             width: location.column.width + 1,
-            position: state.props?.disableFixedCellEditor ? 'absolute' : 'fixed',
+            position: 'fixed'
         }}
     >
         {cellTemplate.render(currentlyEditedCell, true, (cell: Compatible<Cell>, commit: boolean) => {

--- a/src/lib/Functions/cellEditorCalculator.ts
+++ b/src/lib/Functions/cellEditorCalculator.ts
@@ -67,20 +67,19 @@ export const calculateCellEditorPosition = (positionState: PositionState): CellE
       offsetTop = top;
   }
 
-  const getCellEditorPosition = (isFixedDisabled = false) => {
-    if (isFixedDisabled) return { left: location.column.left, top: location.row.top };
-    return {
-      left: location.column.left + calculatedXAxisOffset(location, state) + offsetLeft + left - scrollLeft,
-      top: location.row.top + calculatedYAxisOffset(location, state) + offsetTop + top - scrollTop,
-    };
-  };
-
   // React StrictMode calls reducer two times to eliminate any side-effects
   // this function is a reducer so we need to add the state and location to positionState
   // in order to get them in the second call
   return {
     state,
     location,
-    ...getCellEditorPosition(state.props?.disableFixedCellEditor)
+    left: location.column.left + calculatedXAxisOffset(location, state as State)
+        + offsetLeft
+        + left
+        - scrollLeft,
+    top: location.row.top + calculatedYAxisOffset(location, state as State)
+        + offsetTop
+        + top
+        - scrollTop
   };
 }

--- a/src/lib/Model/PublicModel.ts
+++ b/src/lib/Model/PublicModel.ts
@@ -64,8 +64,6 @@ export interface ReactGridProps {
     readonly enableGroupIdRender?: boolean;
     /** Set `true` to disable virtual scrolling (by default `false`) */
     readonly disableVirtualScrolling?: boolean;
-    /** Set `true` to disable "scroll following" feature of cell editor */
-    readonly disableFixedCellEditor?: boolean;
     /** 
      * Horizontal breakpoint in percents (%) of ReactGrid scrollable parent element width. 
      * Disables sticky when the sum of the sizes of sticky panes overflows


### PR DESCRIPTION
Reverts CellEditor positioning calculation changes on disabled fixed position.