### PR TITLE
Fix default border color

### DIFF
--- a/src/lib/Components/CellRenderer.tsx
+++ b/src/lib/Components/CellRenderer.tsx
@@ -69,7 +69,7 @@ export const CellRenderer: React.FC<CellRendererProps> = ({
     const storePropertyAndDefaultValue = storeBorderAndCell(borders, cell);
     const bordersWidth = getBorderProperties(storePropertyAndDefaultValue('width', '1px')),
         bordersStyle = getBorderProperties(storePropertyAndDefaultValue('style', 'solid')),
-        bordersColor = getBorderProperties(storePropertyAndDefaultValue('color', 'e8e8e8'));
+        bordersColor = getBorderProperties(storePropertyAndDefaultValue('color', '#e8e8e8'));
 
     const bordersProps = {
         borderLeftWidth: bordersWidth.left,


### PR DESCRIPTION
In the current version the gird has a black default border color (or rather a text-color default border color), since the default value is not a color. 
This PR addresses this and restores the original default border color.