### PR TITLE
respect locale when parsing pasted numbers

### DIFF
--- a/src/lib/Functions/handlePaste.ts
+++ b/src/lib/Functions/handlePaste.ts
@@ -4,6 +4,18 @@ import { ClipboardEvent } from '../Model/domEventsTypes';
 import { getActiveSelectedRange } from './getActiveSelectedRange';
 import { pasteData } from './pasteData';
 
+const decimalSeparator = (1.1).toLocaleString().substring(1, 2);
+const thousandSeparator = (1000).toLocaleString().substring(1, 2);
+
+function parseFloatLocale(text: string): number {
+    return parseFloat(
+      text
+        .replace(thousandSeparator, "")
+        .replace(decimalSeparator, ".")
+        .replace(/[^0-9.-]/g, "")
+    );
+}
+
 export function handlePaste(event: ClipboardEvent, state: State): State {
     const activeSelectedRange = getActiveSelectedRange(state);
     if (!activeSelectedRange) {
@@ -31,7 +43,7 @@ export function handlePaste(event: ClipboardEvent, state: State): State {
             tableRows[ri].children[ci].getAttribute("data-reactgrid");
           const data = rawData && JSON.parse(rawData);
           const text = tableRows[ri].children[ci].innerHTML;
-          row.push(data ? data : { type: "text", text, value: parseFloat(text) });
+          row.push(data ? data : { type: "text", text, value: parseFloatLocale(text) });
         }
         pastedRows.push(row);
       }
@@ -42,10 +54,9 @@ export function handlePaste(event: ClipboardEvent, state: State): State {
         .map((line: string) =>
           line
             .split("\t")
-            .map((t) => ({ type: "text", text: t, value: parseFloat(t) }))
+            .map((t) => ({ type: "text", text: t, value: parseFloatLocale(t) }))
         );
     }
     event.preventDefault();
     return { ...pasteData(state, pastedRows) };
-  }
-  
+}

--- a/src/lib/Functions/handlePaste.ts
+++ b/src/lib/Functions/handlePaste.ts
@@ -43,7 +43,7 @@ export function handlePaste(event: ClipboardEvent, state: State): State {
             tableRows[ri].children[ci].getAttribute("data-reactgrid");
           const data = rawData && JSON.parse(rawData);
           const text = tableRows[ri].children[ci].innerHTML;
-          row.push(data ? data : { type: "text", text, value: parseFloatLocale(text) });
+          row.push(data ? data : { type: "text", text, value: localeParseFloat(text) });
         }
         pastedRows.push(row);
       }
@@ -54,7 +54,7 @@ export function handlePaste(event: ClipboardEvent, state: State): State {
         .map((line: string) =>
           line
             .split("\t")
-            .map((t) => ({ type: "text", text: t, value: parseFloatLocale(t) }))
+            .map((t) => ({ type: "text", text: t, value: localeParseFloat(t) }))
         );
     }
     event.preventDefault();

--- a/src/lib/Functions/handlePaste.ts
+++ b/src/lib/Functions/handlePaste.ts
@@ -7,7 +7,7 @@ import { pasteData } from './pasteData';
 const decimalSeparator = (1.1).toLocaleString().substring(1, 2);
 const thousandSeparator = (1000).toLocaleString().substring(1, 2);
 
-function parseFloatLocale(text: string): number {
+function localeParseFloat(text: string): number {
     return parseFloat(
       text
         .replace(thousandSeparator, "")


### PR DESCRIPTION
When pasting number values into reactgrid that are formatted with "." as thousands separator and "," as decimal separator, the number value will not be parsed correctly
This PR fixes this by determining the separator types (albeit a bit hacky?) and preprocessing the value before passing it to `parseFloat`.