### PR TITLE
When the last line is bottomed, the right-click context menu is also …

### DIFF
--- a/src/lib/Components/ContextMenu.tsx
+++ b/src/lib/Components/ContextMenu.tsx
@@ -18,15 +18,29 @@ import { getSelectedLocations } from "../Functions/getSelectedLocations";
 import { useReactGridState } from "./StateProvider";
 
 export const ContextMenu: React.FC = () => {
+  const targetRef = React.useRef<HTMLDivElement>(null);
   const state = useReactGridState();
-
-  if (
-    state.contextMenuPosition.top === -1 &&
-    state.contextMenuPosition.left === -1
-  )
-    return null;
-
   const { contextMenuPosition, selectedIds, selectionMode } = state;
+  const clickX = contextMenuPosition.left;
+  const clickY = contextMenuPosition.top;
+  if (clickY === -1 && clickX === -1) return null;
+  const screenW = window.innerWidth;
+  const screenH = window.innerHeight;
+  const menuW = targetRef?.current?.offsetWidth || 194;
+  const menuH = targetRef?.current?.offsetHeight || 150;
+
+  // Check to see if it's near the bottom
+  if (screenH - clickY < menuH) {
+    contextMenuPosition.top = screenH - menuH - 10;
+  } else {
+    contextMenuPosition.top = clickY;
+  }
+  // Check to see if it's close to the right
+  if (screenW - clickX < menuW) {
+    contextMenuPosition.left = screenW - menuW - 10;
+  } else {
+    contextMenuPosition.left = clickX;
+  }
 
   let contextMenuOptions = customContextMenuOptions(state);
 
@@ -45,6 +59,7 @@ export const ContextMenu: React.FC = () => {
 
   return (
     <div
+      ref={targetRef}
       className="rg-context-menu"
       style={{
         top: contextMenuPosition.top + "px",

--- a/src/lib/Components/ContextMenu.tsx
+++ b/src/lib/Components/ContextMenu.tsx
@@ -23,23 +23,24 @@ export const ContextMenu: React.FC = () => {
   const { contextMenuPosition, selectedIds, selectionMode } = state;
   const clickX = contextMenuPosition.left;
   const clickY = contextMenuPosition.top;
-  if (clickY === -1 && clickX === -1) return null;
-  const screenW = window.innerWidth;
-  const screenH = window.innerHeight;
-  const menuW = targetRef?.current?.offsetWidth || 194;
-  const menuH = targetRef?.current?.offsetHeight || 150;
+  if (clickY !== -1 && clickX !== -1 && targetRef.current) {
+    const screenW = window.innerWidth;
+    const screenH = window.innerHeight;
+    const menuW = targetRef.current.offsetWidth;
+    const menuH = targetRef.current.offsetHeight;
 
-  // Check to see if it's near the bottom
-  if (screenH - clickY < menuH) {
-    contextMenuPosition.top = screenH - menuH - 10;
-  } else {
-    contextMenuPosition.top = clickY;
-  }
-  // Check to see if it's close to the right
-  if (screenW - clickX < menuW) {
-    contextMenuPosition.left = screenW - menuW - 10;
-  } else {
-    contextMenuPosition.left = clickX;
+    // Check to see if it's near the bottom
+    if (screenH - clickY < menuH) {
+      contextMenuPosition.top = screenH - menuH - 20;
+    } else {
+      contextMenuPosition.top = clickY;
+    }
+    // Check to see if it's close to the right
+    if (screenW - clickX < menuW) {
+      contextMenuPosition.left = screenW - menuW - 20;
+    } else {
+      contextMenuPosition.left = clickX;
+    }
   }
 
   let contextMenuOptions = customContextMenuOptions(state);
@@ -62,6 +63,8 @@ export const ContextMenu: React.FC = () => {
       ref={targetRef}
       className="rg-context-menu"
       style={{
+        // Visually disappear but maintain the layout
+        visibility: clickY === -1 && clickX === -1 ? "hidden" : "visible",
         top: contextMenuPosition.top + "px",
         left: contextMenuPosition.left + "px",
       }}

--- a/src/lib/Components/ContextMenu.tsx
+++ b/src/lib/Components/ContextMenu.tsx
@@ -18,26 +18,34 @@ import { getSelectedLocations } from "../Functions/getSelectedLocations";
 import { useReactGridState } from "./StateProvider";
 
 export const ContextMenu: React.FC = () => {
-  const targetRef = React.useRef<HTMLDivElement>(null);
+  const contextMenuElRef = React.useRef<HTMLDivElement>(null);
   const state = useReactGridState();
   const { contextMenuPosition, selectedIds, selectionMode } = state;
+
   const clickPositionX = contextMenuPosition.left;
   const clickPositionY = contextMenuPosition.top;
-  if (clickPositionY !== -1 && clickPositionX !== -1 && targetRef.current) {
+
+  if (
+    clickPositionY !== -1 &&
+    clickPositionX !== -1 &&
+    contextMenuElRef.current
+  ) {
     const screenWidth = window.innerWidth;
     const screenHeight = window.innerHeight;
-    const menuWidth = targetRef.current.offsetWidth;
-    const menuHeight = targetRef.current.offsetHeight;
+    const menuWidth = contextMenuElRef.current.offsetWidth;
+    const menuHeight = contextMenuElRef.current.offsetHeight;
+    const SAFETY_OFFSET = 20;
 
     // Check to see if it's near the bottom
     if (screenHeight - clickPositionY < menuHeight) {
-      contextMenuPosition.top = screenHeight - menuHeight - 20;
+      contextMenuPosition.top = screenHeight - menuHeight - SAFETY_OFFSET;
     } else {
       contextMenuPosition.top = clickPositionY;
     }
+
     // Check to see if it's close to the right
     if (screenWidth - clickPositionX < menuWidth) {
-      contextMenuPosition.left = screenWidth - menuWidth - 20;
+      contextMenuPosition.left = screenWidth - menuWidth - SAFETY_OFFSET;
     } else {
       contextMenuPosition.left = clickPositionX;
     }
@@ -60,11 +68,12 @@ export const ContextMenu: React.FC = () => {
 
   return (
     <div
-      ref={targetRef}
+      ref={contextMenuElRef}
       className="rg-context-menu"
       style={{
-        // Visually disappear but maintain the layout
-        visibility: clickPositionY === -1 && clickPositionX === -1 ? "hidden" : "visible",
+        // Visually disappear but keep the element to retrieve the width and height
+        visibility:
+          clickPositionY === -1 && clickPositionX === -1 ? "hidden" : "visible",
         top: contextMenuPosition.top + "px",
         left: contextMenuPosition.left + "px",
       }}
@@ -145,7 +154,9 @@ function handleContextMenuPaste(state: State) {
           const proState = state as State;
           const { copyRange } = proState;
           let applyMetaData = false;
-          const clipboardRows = isMacOs() ? e.split("\n").filter(Boolean) : e.split("\r\n").filter(Boolean);
+          const clipboardRows = isMacOs()
+            ? e.split("\n").filter(Boolean)
+            : e.split("\r\n").filter(Boolean);
           const clipboard = clipboardRows.map((line) => line.split("\t"));
           if (copyRange && copyRange.rows && copyRange.columns) {
             const isSizeEqual =

--- a/src/lib/Components/ContextMenu.tsx
+++ b/src/lib/Components/ContextMenu.tsx
@@ -21,25 +21,25 @@ export const ContextMenu: React.FC = () => {
   const targetRef = React.useRef<HTMLDivElement>(null);
   const state = useReactGridState();
   const { contextMenuPosition, selectedIds, selectionMode } = state;
-  const clickX = contextMenuPosition.left;
-  const clickY = contextMenuPosition.top;
-  if (clickY !== -1 && clickX !== -1 && targetRef.current) {
-    const screenW = window.innerWidth;
-    const screenH = window.innerHeight;
-    const menuW = targetRef.current.offsetWidth;
-    const menuH = targetRef.current.offsetHeight;
+  const clickPositionX = contextMenuPosition.left;
+  const clickPositionY = contextMenuPosition.top;
+  if (clickPositionY !== -1 && clickPositionX !== -1 && targetRef.current) {
+    const screenWidth = window.innerWidth;
+    const screenHeight = window.innerHeight;
+    const menuWidth = targetRef.current.offsetWidth;
+    const menuHeight = targetRef.current.offsetHeight;
 
     // Check to see if it's near the bottom
-    if (screenH - clickY < menuH) {
-      contextMenuPosition.top = screenH - menuH - 20;
+    if (screenHeight - clickPositionY < menuHeight) {
+      contextMenuPosition.top = screenHeight - menuHeight - 20;
     } else {
-      contextMenuPosition.top = clickY;
+      contextMenuPosition.top = clickPositionY;
     }
     // Check to see if it's close to the right
-    if (screenW - clickX < menuW) {
-      contextMenuPosition.left = screenW - menuW - 20;
+    if (screenWidth - clickPositionX < menuWidth) {
+      contextMenuPosition.left = screenWidth - menuWidth - 20;
     } else {
-      contextMenuPosition.left = clickX;
+      contextMenuPosition.left = clickPositionX;
     }
   }
 
@@ -64,7 +64,7 @@ export const ContextMenu: React.FC = () => {
       className="rg-context-menu"
       style={{
         // Visually disappear but maintain the layout
-        visibility: clickY === -1 && clickX === -1 ? "hidden" : "visible",
+        visibility: clickPositionY === -1 && clickPositionX === -1 ? "hidden" : "visible",
         top: contextMenuPosition.top + "px",
         left: contextMenuPosition.left + "px",
       }}

--- a/src/lib/Functions/handleContextMenu.ts
+++ b/src/lib/Functions/handleContextMenu.ts
@@ -8,15 +8,9 @@ export function handleContextMenu(event: PointerEvent, state: State): State {
     event.preventDefault();
     const clickX = event.clientX;
     const clickY = event.clientY;
-    const top = window.innerHeight - clickY > 25;
-    const right = window.innerWidth - clickX > 120;
-    const bottom = !top;
-    const left = !right;
     const contextMenuPosition = state.contextMenuPosition;
-    if (top) { contextMenuPosition.top = clickY; }
-    if (right) { contextMenuPosition.left = clickX + 5; }
-    if (bottom) { contextMenuPosition.top = clickY - 25 - 5; }
-    if (left) { contextMenuPosition.left = clickX - 120 - 5; }
+    contextMenuPosition.top = clickY;
+    contextMenuPosition.left = clickX;
     const focusedLocation = getLocationFromClient(state, clickX, clickY);
     if (!state.selectedRanges.find(range => range.contains(focusedLocation))) {
         state = focusLocation(state, focusedLocation)


### PR DESCRIPTION
…bottomed, and the menu item is covered and cannot be selected #286

Resolved，When the last line is bottom, the right-click context menu is no longer covered, can be selected

![When the last line is bottomed, the right-click context menu is also bottomed, and the menu item is covered and cannot be selected](https://github.com/silevis/reactgrid/assets/36500514/f78e99a3-ff15-4a9a-a9f0-8d2af0cc3da1)
