### PR TITLE
Refactor behaviors

### DIFF
--- a/src/behaviors/CellSelectionBehavior.ts
+++ b/src/behaviors/CellSelectionBehavior.ts
@@ -1,18 +1,17 @@
 import { Behavior } from "../types/Behavior";
+import { NO_CELL_LOCATION } from "../types/InternalModel";
 import { Cell } from "../types/PublicModel";
-import { getCellIndexesFromPointerLocation } from "../utils/getCellIndexesFromPointerLocation";
+import { ReactGridStore } from "../types/ReactGridStore.ts";
+import { findMinimalSelectedArea } from "../utils/findMinimalSelectedArea.ts";
+import { getCellContainer } from "../utils/getCellContainer.ts";
 import { getCellIndexesFromContainerElement } from "../utils/getCellIndexes";
+import { getCellIndexesFromPointerLocation } from "../utils/getCellIndexesFromPointerLocation";
 import { getNonStickyCellContainer } from "../utils/getNonStickyCellContainer";
-import { scrollTowardsSticky } from "../utils/scrollTowardsSticky";
-import { isMobile } from "../utils/isMobile";
+import { isCellSticky } from "../utils/isCellSticky.ts";
+import isDevEnvironment from "../utils/isDevEnvironment";
 import { getScrollableParent } from "../utils/scrollHelpers";
 import { scrollToElementEdge } from "../utils/scrollToElementEdge";
-import isDevEnvironment from "../utils/isDevEnvironment";
-import { ReactGridStore } from "../types/ReactGridStore.ts";
-import { NO_CELL_LOCATION } from "../types/InternalModel";
-import { findMinimalSelectedArea } from "../utils/findMinimalSelectedArea.ts";
-import { isCellSticky } from "../utils/isCellSticky.ts";
-import { getCellContainer } from "../utils/getCellContainer.ts";
+import { scrollTowardsSticky } from "../utils/scrollTowardsSticky";
 
 const devEnvironment = isDevEnvironment();
 
@@ -68,9 +67,6 @@ export const CellSelectionBehavior: Behavior = {
   id: "CellSelection",
 
   handlePointerMove(event, store) {
-    if (isMobile()) {
-      return store;
-    }
     devEnvironment && console.log("CSB/handlePointerMove");
 
     const { clientX, clientY } = event;
@@ -100,10 +96,7 @@ export const CellSelectionBehavior: Behavior = {
     return tryExpandingTowardsCell(store, cell, rowIndex, colIndex);
   },
 
-  handlePointerUp(_event, store) {
-    if (isMobile()) {
-      return store;
-    }
+  handlePointerUp(event, store) {
     const DefaultBehavior = store.getBehavior("Default");
 
     return {
@@ -112,8 +105,8 @@ export const CellSelectionBehavior: Behavior = {
     };
   },
 
-  handlePointerDownTouch(_event, store) {
-    devEnvironment && console.log("CSB/handleTouchStart");
+  handlePointerDownTouch(event, store) {
+    devEnvironment && console.log("CSB/handlePointerDownTouch");
 
     const DefaultBehavior = store.getBehavior("Default");
 
@@ -124,21 +117,21 @@ export const CellSelectionBehavior: Behavior = {
   },
 
   handlePointerUpTouch(event, store) {
-    devEnvironment && console.log("CSB/handleTouchEnd");
+    devEnvironment && console.log("CSB/handlePointerUpTouch");
 
     return store;
   },
 
   handlePointerEnter(event, store) {
+
     return store;
   },
 
   handlePointerMoveTouch(event, store) {
-    devEnvironment && console.log("CSB/handleTouchMove");
-    event.preventDefault(); // disable move/scroll move
+    devEnvironment && console.log("CSB/handlePointerMoveTouch");
 
-    const touchedElement = event.touches[0]; //  * This might be not a good idea to do it that way...
-    const { clientX, clientY } = touchedElement;
+    const { clientX, clientY } = event;
+
     const { rowIndex, colIndex } = getCellIndexesFromPointerLocation(clientX, clientY);
     const cell = store.getCellByIndexes(rowIndex, colIndex);
 
@@ -147,7 +140,9 @@ export const CellSelectionBehavior: Behavior = {
     }
 
     const isStickyCell = isCellSticky(store, cell);
-    const cellContainer = isStickyCell ? getCellContainer(store, cell) : getNonStickyCellContainer(clientX, clientY);
+    const cellContainer = (
+      isStickyCell ? getCellContainer(store, cell) : getNonStickyCellContainer(clientX, clientY)
+    ) as HTMLElement | undefined;
 
     if (cellContainer) {
       const scrollableParent = getScrollableParent(cellContainer as HTMLElement, true);
@@ -155,7 +150,7 @@ export const CellSelectionBehavior: Behavior = {
         scrollableParent && "clientWidth" in scrollableParent && "clientHeight" in scrollableParent;
 
       scrollableParentIsNotAWindow ? scrollToElementEdge({ x: clientX, y: clientY }, scrollableParent) : () => {}; // TODO: scrollToWindowEdge({ x: clientX, y: clientY }); - function not implemented yet!
-      // scrollToWindowEdge - not possible to test in Ladle environment, due to clientX/Y acting like pageX/Y
+      // * scrollToWindowEdge - not possible to test in Ladle environment, due to clientX/Y acting like pageX/Y
 
       if (isStickyCell) {
         const nonStickyRowsAndColumns = getCellIndexesFromContainerElement(cellContainer);
@@ -167,5 +162,10 @@ export const CellSelectionBehavior: Behavior = {
     }
 
     return tryExpandingTowardsCell(store, cell, rowIndex, colIndex);
+  },
+
+  handlePointerEnterTouch(event, store) {
+
+    return store;
   },
 };

--- a/src/behaviors/CellSelectionBehavior.ts
+++ b/src/behaviors/CellSelectionBehavior.ts
@@ -112,7 +112,7 @@ export const CellSelectionBehavior: Behavior = {
     };
   },
 
-  handleTouchStart(_event, store) {
+  handlePointerDownTouch(_event, store) {
     devEnvironment && console.log("CSB/handleTouchStart");
 
     const DefaultBehavior = store.getBehavior("Default");
@@ -123,7 +123,7 @@ export const CellSelectionBehavior: Behavior = {
     };
   },
 
-  handleTouchEnd(event, store) {
+  handlePointerUpTouch(event, store) {
     devEnvironment && console.log("CSB/handleTouchEnd");
 
     return store;
@@ -133,7 +133,7 @@ export const CellSelectionBehavior: Behavior = {
     return store;
   },
 
-  handleTouchMove(event, store) {
+  handlePointerMoveTouch(event, store) {
     devEnvironment && console.log("CSB/handleTouchMove");
     event.preventDefault(); // disable move/scroll move
 

--- a/src/behaviors/DefaultBehavior.ts
+++ b/src/behaviors/DefaultBehavior.ts
@@ -52,7 +52,7 @@ export const DefaultBehavior = (config: DefaultBehaviorConfig = CONFIG_DEFAULTS)
   },
 
   handlePointerMove: (event, store) => {
-    if (isMobile()) {
+    if (hasTouchSupport()) {
       return store;
     }
     devEnvironment && console.log("DB/handlePointerMove");
@@ -96,7 +96,7 @@ export const DefaultBehavior = (config: DefaultBehaviorConfig = CONFIG_DEFAULTS)
     return handleKeyDown(event, store, { moveHorizontallyOnEnter: config.moveHorizontallyOnEnter });
   },
 
-  handleTouchStart: function (event, store) {
+  handlePointerDownTouch: function (event, store) {
     if (!hasTouchSupport()) {
       return store;
     }
@@ -127,7 +127,7 @@ export const DefaultBehavior = (config: DefaultBehaviorConfig = CONFIG_DEFAULTS)
     return store;
   },
 
-  handleTouchMove: function (_event, store) {
+  handlePointerMoveTouch: function (_event, store) {
     if (!hasTouchSupport()) {
       return store;
     }
@@ -137,7 +137,7 @@ export const DefaultBehavior = (config: DefaultBehaviorConfig = CONFIG_DEFAULTS)
     return store;
   },
 
-  handleTouchEnd: function (event, store) {
+  handlePointerUpTouch: function (event, store) {
     if (!hasTouchSupport()) {
       return store;
     }

--- a/src/components/CellWrapper.tsx
+++ b/src/components/CellWrapper.tsx
@@ -24,6 +24,7 @@ const CellWrapper: FC<CellWrapperProps> = ({ children, targetInputRef, ...wrappe
         ...customStyle,
         padding: ".1rem .2rem",
         textAlign: "center",
+        touchAction: isFocused ? "none" : "auto",
         ...ctx.containerStyle,
       }}
     >

--- a/src/components/GridWrapper.tsx
+++ b/src/components/GridWrapper.tsx
@@ -38,29 +38,6 @@ const GridWrapper: FC<PropsWithChildren<GridWrapperProps>> = ({ reactGridId, sty
     }
   }, [styledRanges]); // DO NOT USE ANYTHING RELATED TO STORE IN DEPENDENCY ARRAY!
 
-  // Force touch-event listeners to be non-passive
-  useEffect(() => {
-    if (reactGridElement.current) {
-      const element = reactGridElement.current;
-      const touchStartListener = (e) => withStoreApi(e, currentBehavior?.handleTouchStart);
-      const touchMoveListener = (e) => withStoreApi(e, currentBehavior?.handleTouchMove);
-      const touchEndListener = (e) => withStoreApi(e, currentBehavior?.handleTouchEnd);
-      const touchCancelListener = (e) => withStoreApi(e, currentBehavior?.handleTouchCancel);
-
-      element.addEventListener("touchstart", touchStartListener, { passive: false });
-      element.addEventListener("touchmove", touchMoveListener, { passive: false });
-      element.addEventListener("touchend", touchEndListener, { passive: false });
-      element.addEventListener("touchcancel", touchCancelListener, { passive: false });
-
-      return () => {
-        element.removeEventListener("touchstart", touchStartListener);
-        element.removeEventListener("touchmove", touchMoveListener);
-        element.removeEventListener("touchend", touchEndListener);
-        element.removeEventListener("touchcancel", touchCancelListener);
-      };
-    }
-  }, [reactGridElement, currentBehavior]);
-
   return (
     <div
       css={css}

--- a/src/controllers/handlePointerDown.ts
+++ b/src/controllers/handlePointerDown.ts
@@ -6,15 +6,12 @@ import { isTheSameCell } from "../utils/isTheSameCell.ts";
 import { updateStoreWithApiAndEventHandler } from "../utils/updateStoreWithApiAndEventHandler.ts";
 import { ReactGridStore } from "../types/ReactGridStore.ts";
 
-export const handlePointerDown = (
-  pointerDownEvent: React.PointerEvent<HTMLDivElement>,
-  storeApi: StoreApi<ReactGridStore>
-) => {
+export const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>, storeApi: StoreApi<ReactGridStore>) => {
   function getNewestState() {
     return storeApi.getState();
   }
 
-  const usedTouch = pointerDownEvent.pointerType !== "mouse"; // * keep in mind there is also "pen" pointerType
+  const usedTouch = event.pointerType !== "mouse"; // * keep in mind there is also "pen" pointerType
 
   const updateWithStoreApi = <TEvent extends React.SyntheticEvent<HTMLElement> | PointerEvent>(
     event: TEvent,
@@ -25,32 +22,32 @@ export const handlePointerDown = (
 
   let previousCellContainer: HTMLElement | null = null;
 
-  const handlePointerMove = (pointerMoveEvent: PointerEvent) => {
+  const handlePointerMove = (event: PointerEvent) => {
     const handler = usedTouch
       ? getNewestState().currentBehavior.handlePointerMoveTouch
       : getNewestState().currentBehavior.handlePointerMove;
 
-    updateWithStoreApi(pointerMoveEvent, handler);
+    updateWithStoreApi(event, handler);
 
-    const hoveredCellContainer = getCellContainerFromPoint(pointerMoveEvent.clientX, pointerMoveEvent.clientY);
+    const hoveredCellContainer = getCellContainerFromPoint(event.clientX, event.clientY);
 
     if (hoveredCellContainer) {
       if (previousCellContainer && !isTheSameCell(hoveredCellContainer, previousCellContainer)) {
-        handlePointerEnter(pointerMoveEvent);
+        handlePointerEnter(event);
       }
       previousCellContainer = hoveredCellContainer;
     }
   };
 
-  const handlePointerEnter = (pointerEnterEvent: PointerEvent) => {
+  const handlePointerEnter = (event: PointerEvent) => {
     const handler = usedTouch
       ? getNewestState().currentBehavior.handlePointerEnterTouch
       : getNewestState().currentBehavior.handlePointerEnter;
 
-    updateWithStoreApi(pointerEnterEvent, handler);
+    updateWithStoreApi(event, handler);
   };
 
-  const handlePointerUp = (pointerUpEvent: PointerEvent) => {
+  const handlePointerUp = (event: PointerEvent) => {
     // Remove listeners after pointerUp
     window.removeEventListener("pointermove", handlePointerMove);
     window.removeEventListener("pointerup", handlePointerUp);
@@ -59,7 +56,7 @@ export const handlePointerDown = (
       ? getNewestState().currentBehavior.handlePointerUpTouch
       : getNewestState().currentBehavior.handlePointerUp;
 
-    updateWithStoreApi(pointerUpEvent, handler);
+    updateWithStoreApi(event, handler);
   };
 
   // Remove listeners after pointerDown
@@ -68,5 +65,5 @@ export const handlePointerDown = (
 
   const handler = usedTouch ? store.currentBehavior.handlePointerDownTouch : store.currentBehavior.handlePointerDown;
 
-  updateWithStoreApi(pointerDownEvent, handler);
+  updateWithStoreApi(event, handler);
 };

--- a/src/controllers/handlePointerDown.ts
+++ b/src/controllers/handlePointerDown.ts
@@ -14,6 +14,8 @@ export const handlePointerDown = (
     return storeApi.getState();
   }
 
+  const usedTouch = pointerDownEvent.pointerType !== "mouse"; // * keep in mind there is also "pen" pointerType
+
   const updateWithStoreApi = <TEvent extends React.SyntheticEvent<HTMLElement> | PointerEvent>(
     event: TEvent,
     handler?: HandlerFn<TEvent>
@@ -24,7 +26,11 @@ export const handlePointerDown = (
   let previousCellContainer: HTMLElement | null = null;
 
   const handlePointerMove = (pointerMoveEvent: PointerEvent) => {
-    updateWithStoreApi(pointerMoveEvent, getNewestState().currentBehavior.handlePointerMove);
+    const handler = usedTouch
+      ? getNewestState().currentBehavior.handlePointerMoveTouch
+      : getNewestState().currentBehavior.handlePointerMove;
+
+    updateWithStoreApi(pointerMoveEvent, handler);
 
     const hoveredCellContainer = getCellContainerFromPoint(pointerMoveEvent.clientX, pointerMoveEvent.clientY);
 
@@ -37,7 +43,11 @@ export const handlePointerDown = (
   };
 
   const handlePointerEnter = (pointerEnterEvent: PointerEvent) => {
-    updateWithStoreApi(pointerEnterEvent, getNewestState().currentBehavior.handlePointerEnter);
+    const handler = usedTouch
+      ? getNewestState().currentBehavior.handlePointerEnterTouch
+      : getNewestState().currentBehavior.handlePointerEnter;
+
+    updateWithStoreApi(pointerEnterEvent, handler);
   };
 
   const handlePointerUp = (pointerUpEvent: PointerEvent) => {
@@ -45,12 +55,18 @@ export const handlePointerDown = (
     window.removeEventListener("pointermove", handlePointerMove);
     window.removeEventListener("pointerup", handlePointerUp);
 
-    updateWithStoreApi(pointerUpEvent, getNewestState().currentBehavior.handlePointerUp);
+    const handler = usedTouch
+      ? getNewestState().currentBehavior.handlePointerUpTouch
+      : getNewestState().currentBehavior.handlePointerUp;
+
+    updateWithStoreApi(pointerUpEvent, handler);
   };
 
   // Remove listeners after pointerDown
   window.addEventListener("pointermove", handlePointerMove);
   window.addEventListener("pointerup", handlePointerUp);
 
-  updateWithStoreApi(pointerDownEvent, store.currentBehavior.handlePointerDown);
+  const handler = usedTouch ? store.currentBehavior.handlePointerDownTouch : store.currentBehavior.handlePointerDown;
+
+  updateWithStoreApi(pointerDownEvent, handler);
 };

--- a/src/controllers/handlePointerDown.ts
+++ b/src/controllers/handlePointerDown.ts
@@ -3,8 +3,8 @@ import { StoreApi } from "zustand";
 import { HandlerFn } from "../types/Behavior.ts";
 import { getCellContainerFromPoint } from "../utils/getCellContainerFromPoint.ts";
 import { isTheSameCell } from "../utils/isTheSameCell.ts";
-import { ReactGridStore } from "../utils/reactGridStore.ts";
 import { updateStoreWithApiAndEventHandler } from "../utils/updateStoreWithApiAndEventHandler.ts";
+import { ReactGridStore } from "../types/ReactGridStore.ts";
 
 export const handlePointerDown = (
   pointerDownEvent: React.PointerEvent<HTMLDivElement>,

--- a/src/types/Behavior.ts
+++ b/src/types/Behavior.ts
@@ -10,7 +10,6 @@ export type HandlerFn<TEvent extends React.SyntheticEvent | Event> = (
 ) => ReactGridStore;
 
 export type PointerEventHandler = HandlerFn<React.PointerEvent<HTMLDivElement> | PointerEvent>;
-export type TouchEventHandler = HandlerFn<React.TouchEvent<HTMLDivElement>>;
 export type MouseEventHandler = HandlerFn<React.MouseEvent<HTMLDivElement>>;
 export type KeyboardEventHandler = HandlerFn<React.KeyboardEvent<HTMLDivElement>>;
 export type CompositionEventHandler = HandlerFn<React.CompositionEvent<HTMLDivElement>>;
@@ -25,10 +24,10 @@ export type Behavior = {
   handlePointerLeave?: PointerEventHandler;
   handlePointerUp?: PointerEventHandler;
 
-  handleTouchStart?: TouchEventHandler;
-  handleTouchMove?: TouchEventHandler;
-  handleTouchEnd?: TouchEventHandler;
-  handleTouchCancel?: TouchEventHandler;
+  handlePointerDownTouch?: PointerEventHandler;
+  handlePointerMoveTouch?: PointerEventHandler;
+  handlePointerEnterTouch?: PointerEventHandler;
+  handlePointerUpTouch?: PointerEventHandler;
 
   handleDoubleClick?: MouseEventHandler;
 


### PR DESCRIPTION
Refactor behaviors so they met new requirements (which are based on `handlePointerDown.ts`).
- create pointer touch-type handlers
- use pointerEvents and their types, remove mouse/touch distinction for handlers in `Behavior.ts`
- move touch screen scrolling toggling  from behaviors to `cellWrapper.tsx`