### PR TITLE
add hold detection functionality

### DIFF
--- a/src/behaviors/CellSelectionBehavior.ts
+++ b/src/behaviors/CellSelectionBehavior.ts
@@ -123,7 +123,16 @@ export const CellSelectionBehavior: Behavior = {
   },
 
   handlePointerEnter(event, store) {
+    return store;
+  },
 
+  handlePointerHold: function (event, store) {
+    devEnvironment && console.log("CSB/handlePointerHold");
+    return store;
+  },
+
+  handlePointerHoldTouch: function (event, store) {
+    devEnvironment && console.log("CSB/handlePointerHoldTouch");
     return store;
   },
 
@@ -165,7 +174,6 @@ export const CellSelectionBehavior: Behavior = {
   },
 
   handlePointerEnterTouch(event, store) {
-
     return store;
   },
 };

--- a/src/behaviors/DefaultBehavior.ts
+++ b/src/behaviors/DefaultBehavior.ts
@@ -58,6 +58,16 @@ export const DefaultBehavior = (config: DefaultBehaviorConfig = CONFIG_DEFAULTS)
     return store;
   },
 
+  handlePointerHold: function (event, store) {
+    devEnvironment && console.log("DB/handlePointerHold");
+    return store;
+  },
+
+  handlePointerHoldTouch: function (event, store) {
+    devEnvironment && console.log("DB/handlePointerHoldTouch");
+    return store;
+  },
+
   handleKeyDown: function (event, store) {
     return handleKeyDown(event, store, { moveHorizontallyOnEnter: config.moveHorizontallyOnEnter });
   },

--- a/src/controllers/handlePointerDown.ts
+++ b/src/controllers/handlePointerDown.ts
@@ -11,7 +11,10 @@ export const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>, sto
 
   let holdTimeoutId: NodeJS.Timeout;
 
-  if (event.button === 2 || usedTouch) {
+  const isRightClick = event.button === 2;
+
+  if (isRightClick || usedTouch) {
+    // invoke the setTimeout callback if handlePointerUp is not called within 500ms (hold event)
     holdTimeoutId = setTimeout(() => {
       const handler = usedTouch
         ? getNewestState().currentBehavior.handlePointerHoldTouch

--- a/src/types/Behavior.ts
+++ b/src/types/Behavior.ts
@@ -11,7 +11,6 @@ export type HandlerFn<TEvent extends React.SyntheticEvent | Event> = (
 
 export type PointerEventHandler = HandlerFn<React.PointerEvent<HTMLDivElement> | PointerEvent>;
 export type PointerHoldEventHandler = HandlerFn<React.PointerEvent<HTMLDivElement> | PointerEvent>;
-export type PointerHoldTouchEventHandler = HandlerFn<React.PointerEvent<HTMLDivElement> | PointerEvent>;
 export type MouseEventHandler = HandlerFn<React.MouseEvent<HTMLDivElement>>;
 export type KeyboardEventHandler = HandlerFn<React.KeyboardEvent<HTMLDivElement>>;
 export type CompositionEventHandler = HandlerFn<React.CompositionEvent<HTMLDivElement>>;

--- a/src/types/Behavior.ts
+++ b/src/types/Behavior.ts
@@ -10,6 +10,8 @@ export type HandlerFn<TEvent extends React.SyntheticEvent | Event> = (
 ) => ReactGridStore;
 
 export type PointerEventHandler = HandlerFn<React.PointerEvent<HTMLDivElement> | PointerEvent>;
+export type PointerHoldEventHandler = HandlerFn<React.PointerEvent<HTMLDivElement> | PointerEvent>;
+export type PointerHoldTouchEventHandler = HandlerFn<React.PointerEvent<HTMLDivElement> | PointerEvent>;
 export type MouseEventHandler = HandlerFn<React.MouseEvent<HTMLDivElement>>;
 export type KeyboardEventHandler = HandlerFn<React.KeyboardEvent<HTMLDivElement>>;
 export type CompositionEventHandler = HandlerFn<React.CompositionEvent<HTMLDivElement>>;
@@ -23,11 +25,13 @@ export type Behavior = {
   handlePointerMove?: PointerEventHandler;
   handlePointerLeave?: PointerEventHandler;
   handlePointerUp?: PointerEventHandler;
+  handlePointerHold?: PointerHoldEventHandler;
 
   handlePointerDownTouch?: PointerEventHandler;
   handlePointerMoveTouch?: PointerEventHandler;
   handlePointerEnterTouch?: PointerEventHandler;
   handlePointerUpTouch?: PointerEventHandler;
+  handlePointerHoldTouch?: PointerHoldEventHandler;
 
   handleDoubleClick?: MouseEventHandler;
 

--- a/src/utils/updateStoreWithApiAndEventHandler.ts
+++ b/src/utils/updateStoreWithApiAndEventHandler.ts
@@ -18,4 +18,4 @@ export const updateStoreWithApiAndEventHandler = <TEvent extends React.Synthetic
   }
 
   return store;
-}
+};


### PR DESCRIPTION
**detectHold** function that handles the detection and completion of a hold action for both mouse and touch pointer types. 
It includes the following features:
- **hold detection**: this could be a right mouse click or a touch event. It sets up an interval to check the duration of the hold and listens for a pointer up event.

- **hold completion**: when a pointer up event occurs, the function terminates the hold detection process. If the hold duration was 200 milliseconds or more, it resolves a promise to indicate that the hold action has been completed.