### PR TITLE
modify handleKeyDown to listen to caps lock

### DIFF
--- a/src/lib/CellTemplates/ChevronCellTemplate.tsx
+++ b/src/lib/CellTemplates/ChevronCellTemplate.tsx
@@ -47,11 +47,11 @@ export class ChevronCellTemplate implements CellTemplate<ChevronCell> {
         return this.getCompatibleCell({ ...cell, isExpanded: cellToMerge.isExpanded, text: cellToMerge.text })
     }
 
-    handleKeyDown(cell: Compatible<ChevronCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<ChevronCell>, enableEditMode: boolean } {
+    handleKeyDown(cell: Compatible<ChevronCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string, capsLock: boolean): { cell: Compatible<ChevronCell>, enableEditMode: boolean } {
         let enableEditMode = keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER;
         const cellCopy = { ...cell };
 
-        const char = getCharFromKey(key, shift);
+        const char = getCharFromKey(key, shift, capsLock);
 
         if (keyCode === keyCodes.SPACE && cellCopy.isExpanded !== undefined && !shift) {
             cellCopy.isExpanded = !cellCopy.isExpanded;

--- a/src/lib/CellTemplates/DateCellTemplate.tsx
+++ b/src/lib/CellTemplates/DateCellTemplate.tsx
@@ -25,7 +25,7 @@ export class DateCellTemplate implements CellTemplate<DateCell> {
         return { ...uncertainCell, date, value, text }
     }
 
-    handleKeyDown(cell: Compatible<DateCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<DateCell>, enableEditMode: boolean } {
+    handleKeyDown(cell: Compatible<DateCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string, capsLock: boolean): { cell: Compatible<DateCell>, enableEditMode: boolean } {
         if (!ctrl && isCharAlphaNumeric(getCharFromKey(key)))
             return { cell: this.getCompatibleCell({ ...cell }), enableEditMode: true }
         return { cell, enableEditMode: keyCode === keyCodes.POINTER || keyCode === keyCodes.ENTER }

--- a/src/lib/CellTemplates/DropdownCellTemplate.tsx
+++ b/src/lib/CellTemplates/DropdownCellTemplate.tsx
@@ -79,12 +79,12 @@ export class DropdownCellTemplate implements CellTemplate<DropdownCell> {
         return `${cell.className ? cell.className : ''}${isOpen}`;
     }
 
-    handleKeyDown(cell: Compatible<DropdownCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<DropdownCell>, enableEditMode: boolean } {
+    handleKeyDown(cell: Compatible<DropdownCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string, capsLock: boolean): { cell: Compatible<DropdownCell>, enableEditMode: boolean } {
         if ((keyCode === keyCodes.SPACE || keyCode === keyCodes.ENTER) && !shift) {
             return { cell: this.getCompatibleCell({ ...cell, isOpen: !cell.isOpen }), enableEditMode: false };
         }
 
-        const char = getCharFromKey(key, shift);
+        const char = getCharFromKey(key, shift, capsLock);
 
         if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE))
             return { cell: this.getCompatibleCell({ ...cell, inputValue: char, isOpen: !cell.isOpen }), enableEditMode: false }

--- a/src/lib/CellTemplates/EmailCellTemplate.tsx
+++ b/src/lib/CellTemplates/EmailCellTemplate.tsx
@@ -24,8 +24,8 @@ export class EmailCellTemplate implements CellTemplate<EmailCell> {
         return { ...uncertainCell, text, value };
     }
 
-    handleKeyDown(cell: Compatible<EmailCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<EmailCell>, enableEditMode: boolean } {
-        const char = getCharFromKey(key, shift);
+    handleKeyDown(cell: Compatible<EmailCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string, capsLock: boolean): { cell: Compatible<EmailCell>, enableEditMode: boolean } {
+        const char = getCharFromKey(key, shift, capsLock);
 
         if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE))
             return { cell: { ...cell, text: char }, enableEditMode: true }

--- a/src/lib/CellTemplates/NumberCellTemplate.tsx
+++ b/src/lib/CellTemplates/NumberCellTemplate.tsx
@@ -34,7 +34,7 @@ export class NumberCellTemplate implements CellTemplate<NumberCell> {
         return { ...uncertainCell, value: displayValue, text }
     }
 
-    handleKeyDown(cell: Compatible<NumberCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<NumberCell>; enableEditMode: boolean } {
+    handleKeyDown(cell: Compatible<NumberCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string, capsLock: boolean): { cell: Compatible<NumberCell>; enableEditMode: boolean } {
         if (isNumpadNumericKey(keyCode)) keyCode -= 48;
         const char = getCharFromKey(key);
         if (!ctrl && isCharAllowedOnNumberInput(char)) {

--- a/src/lib/CellTemplates/TextCellTemplate.tsx
+++ b/src/lib/CellTemplates/TextCellTemplate.tsx
@@ -35,8 +35,8 @@ export class TextCellTemplate implements CellTemplate<TextCell> {
         return this.getCompatibleCell({ ...cell, text: cellToMerge.text, placeholder: cellToMerge.placeholder })
     }
 
-    handleKeyDown(cell: Compatible<TextCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<TextCell>, enableEditMode: boolean } {
-        const char = getCharFromKey(key, shift);
+    handleKeyDown(cell: Compatible<TextCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string, capsLock: boolean): { cell: Compatible<TextCell>, enableEditMode: boolean } {
+        const char = getCharFromKey(key, shift, capsLock);
 
         if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE))
             return { cell: this.getCompatibleCell({ ...cell, text: char }), enableEditMode: true }

--- a/src/lib/CellTemplates/getCharFromKeyCode.ts
+++ b/src/lib/CellTemplates/getCharFromKeyCode.ts
@@ -208,9 +208,9 @@ export const getCharFromKeyCode = (keyCode: number, isShiftKey = false): string 
     return isShiftKey ? characterMapShift[keyCode] : characterMap[keyCode];
 }
 
-export const getCharFromKey = (key: string, isShiftKey = false): string => {
+export const getCharFromKey = (key: string, isShiftKey = false, isCapsLock = false): string => {
   const language = navigator.language || "en-US";
-  return !isShiftKey
+  return !(isShiftKey || isCapsLock)
     ? key.toLocaleLowerCase(language)
     : key.toLocaleUpperCase(language);
 };

--- a/src/lib/Functions/handleKeyDownOnCellTemplate.ts
+++ b/src/lib/Functions/handleKeyDownOnCellTemplate.ts
@@ -11,7 +11,7 @@ export function handleKeyDownOnCellTemplate(state: State, event: KeyboardEvent):
     }
     const { cell, cellTemplate } = getCompatibleCellAndTemplate(state, location);
     if (cellTemplate.handleKeyDown && !state.currentlyEditedCell) { // TODO need add !(event.shiftKey && event.keyCode === keyCodes.SPACE) to working keycodes (shift + space) in a lower condition
-        const { cell: newCell, enableEditMode } = cellTemplate.handleKeyDown(cell, event.keyCode, isSelectionKey(event), event.shiftKey, event.altKey, event.key);
+        const { cell: newCell, enableEditMode } = cellTemplate.handleKeyDown(cell, event.keyCode, isSelectionKey(event), event.shiftKey, event.altKey, event.key, event.getModifierState("CapsLock"));
         if (JSON.stringify(newCell) !== JSON.stringify(cell) || enableEditMode) {
             if (enableEditMode && !cell.nonEditable) {
                 return { ...state, currentlyEditedCell: newCell }

--- a/src/lib/Model/PublicModel.ts
+++ b/src/lib/Model/PublicModel.ts
@@ -371,6 +371,7 @@ export interface CellTemplate<TCell extends Cell = Cell> {
      * @param {boolean} shift Is `shift` pressed when event is called
      * @param {boolean} alt Is `alt` pressed when event is called
      * @param {string} [key] Represents the value of the key pressed by the user. Optional for backwards compatibility.
+     * @param {boolean} capsLock Is caps lock active when event is called. Optional for backwards compatibility.
      * @returns {{ cell: Compatible<TCell>; enableEditMode: boolean }} Cell data and edit mode either affected by the event or not
     */
     handleKeyDown?(
@@ -379,7 +380,8 @@ export interface CellTemplate<TCell extends Cell = Cell> {
         ctrl: boolean,
         shift: boolean,
         alt: boolean,
-        key?: string
+        key?: string,
+        capsLock?: boolean
     ): { cell: Compatible<TCell>; enableEditMode: boolean };
 
     /** 

--- a/src/test/flagCell/FlagCellTemplate.tsx
+++ b/src/test/flagCell/FlagCellTemplate.tsx
@@ -19,8 +19,8 @@ export class FlagCellTemplate implements CellTemplate<FlagCell> {
         return { ...uncertainCell, text, value };
     }
 
-    handleKeyDown(cell: Compatible<FlagCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string): { cell: Compatible<FlagCell>, enableEditMode: boolean } {
-        const char = getCharFromKey(key, shift);
+    handleKeyDown(cell: Compatible<FlagCell>, keyCode: number, ctrl: boolean, shift: boolean, alt: boolean, key: string, capsLock: boolean): { cell: Compatible<FlagCell>, enableEditMode: boolean } {
+        const char = getCharFromKey(key, shift, capsLock);
 
         if (!ctrl && !alt && isAlphaNumericKey(keyCode) && !(shift && keyCode === keyCodes.SPACE))
             return { cell: { ...cell, text: char }, enableEditMode: true }


### PR DESCRIPTION
There is currently a bug (reproducible on the [live demo](https://reactgrid.com/examples/?example=customization)) such that caps lock is ignored when pressing a letter when a cell is focused but not currently being edited. To reproduce:

1. Turn caps lock on
2. Select a different cell
3. Type the letter "a"
4. Notice that "a" is inserted rather than "A"

This pull request fixes this by adding an optional `capsLock` argument to `CellTemplate`'s `handleKeyDown` method, and modifies the implementations of this method to use `toLocaleUpperCase` rather than `toLocaleLowerCase` if `capsLock` is truthy.