### PR TITLE
fix: blurHandler assumes event target has an id

### DIFF
--- a/src/lib/Model/EventHandlers.ts
+++ b/src/lib/Model/EventHandlers.ts
@@ -18,7 +18,7 @@ export class EventHandlers {
     pasteHandler = (event: ClipboardEvent): void => this.updateState(state => state.currentBehavior.handlePaste(event, state));
     cutHandler = (event: ClipboardEvent): void => this.updateState(state => state.currentBehavior.handleCut(event, state));
     blurHandler = (event: FocusEvent): void => this.updateState(state => {
-        if ((event.target as HTMLInputElement)?.id.startsWith('react-select-')) { // give back focus on react-select dropdown blur
+        if ((event.target as HTMLInputElement)?.id?.startsWith('react-select-')) { // give back focus on react-select dropdown blur
             state.hiddenFocusElement?.focus({ preventScroll: true });
         }
         return state;


### PR DESCRIPTION
The event.target element itself is handled as potentially nullish, but its id property is not. If the target element has no id, the call to startsWith fails.