### PR TITLE
Add disableFixedEditCells to prevent fixed css styling in edit cell

### DIFF
--- a/src/lib/Components/CellEditor.tsx
+++ b/src/lib/Components/CellEditor.tsx
@@ -28,7 +28,7 @@ export interface PositionState<TState extends State = State> {
 
 export const CellEditorRenderer: React.FC = () => {
     const state = useReactGridState();
-    const { currentlyEditedCell, focusedLocation: location } = state;
+    const { currentlyEditedCell, focusedLocation: location, props } = state;
 
     const renders = React.useRef(0);
 
@@ -43,16 +43,24 @@ export const CellEditorRenderer: React.FC = () => {
         return null;
     }
 
+    const style = props?.disableFixedEditCells ? {
+        height: location.row.height + 1,
+        left: location.column.left,
+        position: 'absolute',
+        top: location.row.height * location.row.idx,
+        width: location.column.width + 1,
+    } : {
+        top: position.top && position.top - 1,
+        left: position.left && position.left - 1,
+        height: location.row.height + 1,
+        width: location.column.width + 1,
+        position: 'fixed'
+    };
+
     const cellTemplate = state.cellTemplates[currentlyEditedCell.type];
     return <CellEditor
         cellType={currentlyEditedCell.type}
-        style={{
-            top: position.top && position.top - 1,
-            left: position.left && position.left - 1,
-            height: location.row.height + 1,
-            width: location.column.width + 1,
-            position: 'fixed'
-        }}
+        style={style as React.CSSProperties}
     >
         {cellTemplate.render(currentlyEditedCell, true, (cell: Compatible<Cell>, commit: boolean) => {
             state.currentlyEditedCell = commit ? undefined : cell;

--- a/src/lib/Model/PublicModel.ts
+++ b/src/lib/Model/PublicModel.ts
@@ -61,6 +61,8 @@ export interface ReactGridProps {
     readonly enableRowSelection?: boolean;
     /** Set `true` to enable column selection feature (by default `false`) */
     readonly enableColumnSelection?: boolean;
+    /** Set `true` to enable fixed edit cells during scrolling (by default `false`) */
+    readonly disableFixedEditCells?: boolean;
     /** Object that contains labels of texts used by ReactGrid */
     readonly labels?: TextLabels;
     /** Set `true` to enable full width header (by default `false`, feature is experimental) */


### PR DESCRIPTION
In our usage of the React grid component, when we edit a cell, we do not want the cell to remain in CSS `fixed` styling. 

I've added a `disableFixedEditCells` which attempts to place the cell in an `absolute` position placed on top of the cell being edited. 

This should fall back to sane defaults to prevent any other users from needing to enable or change fixed positioning on cells.