### PR TITLE
Fixes SASS deprecation warning

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -64,15 +64,15 @@
                 pointer-events: auto;
 
                 .rg-resize-handle {
-                    &:hover {
-                        cursor: col-resize;
-                        background-color: $resize-handle-gb-color;
-                    }
-
                     position: absolute;
                     right: 0;
                     width: $resize-handle-line-width;
                     height: 100%;
+                    
+                    &:hover {
+                        cursor: col-resize;
+                        background-color: $resize-handle-gb-color;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes the warning below:

```
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
67  │ ┌                     &:hover {
68  │ │                         cursor: col-resize;
69  │ │                         background-color: $resize-handle-gb-color;
70  │ │                     }
    │ └─── nested rule
... │
72  │                       position: absolute;
    │                       ^^^^^^^^^^^^^^^^^^ declaration
    ╵
    ../../node_modules/@silevis/reactgrid/main.scss 72:21                           @import
    ../../node_modules/@silevis/reactgrid/styles.scss 6:9                           @import
```