### PR TITLE
Fix: The header span issue.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15605,7 +15605,7 @@
     },
     "reactgrid": {
       "name": "@silevis/reactgrid",
-      "version": "5.0.0-alpha.1",
+      "version": "5.0.0-alpha.5",
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@types/lodash.isequal": "^4.5.8",

--- a/reactgrid/lib/utils/cellMatrixBuilder.ts
+++ b/reactgrid/lib/utils/cellMatrixBuilder.ts
@@ -40,8 +40,8 @@ export const cellMatrixBuilder = (
     if (rowIndex === -1) throw new Error(`Row with id "${rowIndex}" isn't defined in rows array`);
     if (colIndex === -1) throw new Error(`Column with id "${colIndex}" isn't defined in columns array`);
 
-    if (process.env.NODE_ENV === "development" && cells.has(`${rowIndex} ${colIndex}`)) {
-      console.warn(`Cell with coordinates [${rowIndex}, ${colIndex}] already exists and will be overwritten!`);
+    if (cells.has(`${rowIndex} ${colIndex}`)) {
+      process.env.NODE_ENV === "development" && console.warn(`Cell with coordinates [${rowIndex}, ${colIndex}] already exists and will be overwritten!`);
       return;
     }
 


### PR DESCRIPTION
Issue #478 

In production mode the header will have issue when one of the header is using colSpan or rowSpan, the other columns will be still visible even after or duplicated

