### PR TITLE
use navigator clipboard if has support #510

### DIFF
--- a/src/lib/Functions/handleCopy.ts
+++ b/src/lib/Functions/handleCopy.ts
@@ -1,40 +1,40 @@
-import { ClipboardEvent } from "../Model/domEventsTypes";
-import { State } from "../Model/State";
-import { getDataToCopy } from "./getDataToCopy";
-import { getActiveSelectedRange } from "./getActiveSelectedRange";
-import { isBrowserSafari } from "./safari";
+import { ClipboardEvent } from '../Model/domEventsTypes';
+import { State } from '../Model/State';
+import { getDataToCopy } from './getDataToCopy';
+import { getActiveSelectedRange } from './getActiveSelectedRange';
+import { isBrowserSafari } from './safari';
 
 export function handleCopy(event: ClipboardEvent, state: State, removeValues = false): State {
-  const activeSelectedRange = getActiveSelectedRange(state);
-  if (!activeSelectedRange) {
-    return state;
-  }
-  const { div } = getDataToCopy(state, activeSelectedRange, removeValues);
-  copyDataCommands(event, state, div);
-  return { ...state, copyRange: activeSelectedRange };
+    const activeSelectedRange = getActiveSelectedRange(state);
+    if (!activeSelectedRange) {
+      return state;
+    }
+    const { div } = getDataToCopy(state, activeSelectedRange, removeValues);
+    copyDataCommands(event, state, div);
+    return { ...state, copyRange: activeSelectedRange };
 }
 
 export function copyDataCommands(event: ClipboardEvent, state: State, div: HTMLDivElement): void {
-  // how document.execCommand is deprecated, we need try use Clipboard API if is available
-  // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
-  const supportNavigatorClipboard = !!navigator?.clipboard?.write;
+    // how document.execCommand is deprecated, we need try use Clipboard API if is available
+    // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
+    const supportNavigatorClipboard = !!navigator?.clipboard?.write;
 
-  if (isBrowserSafari()) {
-    event.clipboardData.setData("text/html", div.innerHTML);
-  } else if (supportNavigatorClipboard) {
-    const clipboardItemData = {
-      "text/html": div.innerHTML,
-    };
-    const clipboardItem = new ClipboardItem(clipboardItemData);
-    navigator.clipboard.write([clipboardItem]).then(() => ({}));
-  } else {
-    document.body.appendChild(div);
-    div.focus();
-    document.execCommand("selectAll", false);
-    document.execCommand("copy");
-    document.body.removeChild(div);
-  }
+    if (isBrowserSafari()) {
+        event.clipboardData.setData('text/html', div.innerHTML);
+    } else if (supportNavigatorClipboard) {
+        const clipboardItemData = {
+          'text/html': div.innerHTML,
+        };
+        const clipboardItem = new ClipboardItem(clipboardItemData);
+        navigator.clipboard.write([clipboardItem]).then(() => ({}));
+    } else {
+        document.body.appendChild(div);
+        div.focus();
+        document.execCommand('selectAll', false);
+        document.execCommand('copy');
+        document.body.removeChild(div);
+    }
 
-  state.hiddenFocusElement?.focus({ preventScroll: true });
-  event.preventDefault();
+    state.hiddenFocusElement?.focus({ preventScroll: true });
+    event.preventDefault();
 }

--- a/src/lib/Functions/handleCopy.ts
+++ b/src/lib/Functions/handleCopy.ts
@@ -1,38 +1,40 @@
-import { ClipboardEvent } from '../Model/domEventsTypes';
-import { State } from '../Model/State';
-import { getDataToCopy } from './getDataToCopy';
-import { getActiveSelectedRange } from './getActiveSelectedRange';
-import { isBrowserSafari } from './safari';
+import { ClipboardEvent } from "../Model/domEventsTypes";
+import { State } from "../Model/State";
+import { getDataToCopy } from "./getDataToCopy";
+import { getActiveSelectedRange } from "./getActiveSelectedRange";
+import { isBrowserSafari } from "./safari";
 
 export function handleCopy(event: ClipboardEvent, state: State, removeValues = false): State {
-    const activeSelectedRange = getActiveSelectedRange(state);
-    if (!activeSelectedRange) {
-      return state;
-    }
-    const { div } = getDataToCopy(state, activeSelectedRange, removeValues);
-    copyDataCommands(event, state, div);
-    return { ...state, copyRange: activeSelectedRange };
+  const activeSelectedRange = getActiveSelectedRange(state);
+  if (!activeSelectedRange) {
+    return state;
+  }
+  const { div } = getDataToCopy(state, activeSelectedRange, removeValues);
+  copyDataCommands(event, state, div);
+  return { ...state, copyRange: activeSelectedRange };
 }
 
 export function copyDataCommands(event: ClipboardEvent, state: State, div: HTMLDivElement): void {
-    const supportNavigatorClipboard = !!navigator?.clipboard?.write;
+  // how document.execCommand is deprecated, we need try use Clipboard API if is available
+  // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
+  const supportNavigatorClipboard = !!navigator?.clipboard?.write;
 
-    if (isBrowserSafari()) {
-        event.clipboardData.setData('text/html', div.innerHTML);
-    } else if (supportNavigatorClipboard) {
-        const clipboardItemData = {
-          "text/html": div.innerHtml,
-        }; 
-        const clipboardItem = new ClipboardItem(clipboardItemData);
-        await navigator.clipboard.write([clipboardItem]);
-    } else {
-        document.body.appendChild(div);
-        div.focus();
-        document.execCommand('selectAll', false);
-        document.execCommand('copy');
-        document.body.removeChild(div);
-    }
+  if (isBrowserSafari()) {
+    event.clipboardData.setData("text/html", div.innerHTML);
+  } else if (supportNavigatorClipboard) {
+    const clipboardItemData = {
+      "text/html": div.innerHTML,
+    };
+    const clipboardItem = new ClipboardItem(clipboardItemData);
+    navigator.clipboard.write([clipboardItem]).then(() => ({}));
+  } else {
+    document.body.appendChild(div);
+    div.focus();
+    document.execCommand("selectAll", false);
+    document.execCommand("copy");
+    document.body.removeChild(div);
+  }
 
-    state.hiddenFocusElement?.focus({ preventScroll: true });
-    event.preventDefault();
+  state.hiddenFocusElement?.focus({ preventScroll: true });
+  event.preventDefault();
 }


### PR DESCRIPTION
This PR is to fix this issues on chrome 134.*

Recent updates on chrome (134.* > ) broken the `.execCommand` in some cases, as reported in some issues like this one https://issues.chromium.org/issues/401379144

https://github.com/silevis/reactgrid/issues/509
https://github.com/silevis/reactgrid/issues/507