### PR TITLE
fix(Functions/handlePaste): prevent pasted string numbers from being …

### DIFF
--- a/src/lib/Functions/handlePaste.ts
+++ b/src/lib/Functions/handlePaste.ts
@@ -51,7 +51,7 @@ export function handlePaste(event: ClipboardEvent, state: State): State {
   }
   
 function parseExcelDate(excelDate: string): Date | null {
-    const isDateString = excelDate.split('.').length > 2;
+    const isDateString = excelDate?.split('.')?.length > 2;
     if(!isDateString) {
       return null;
     }

--- a/src/lib/Functions/handlePaste.ts
+++ b/src/lib/Functions/handlePaste.ts
@@ -51,6 +51,10 @@ export function handlePaste(event: ClipboardEvent, state: State): State {
   }
   
 function parseExcelDate(excelDate: string): Date | null {
+    const isDateString = excelDate.split('.').length > 2;
+    if(!isDateString) {
+      return null;
+    }
     const timestamp = Date.parse(excelDate);
     return isNaN(timestamp) ? null : new Date(timestamp);
 }


### PR DESCRIPTION
…eagerly parsed as dates

it addresses issue https://github.com/silevis/reactgrid/issues/500 and in my test it seems it did the job. It doesn't solve all the cases, but it solves the most urgent one